### PR TITLE
let `_formula` handle implied slopes

### DIFF
--- a/freeride/formula.py
+++ b/freeride/formula.py
@@ -42,21 +42,28 @@ def _formula(equation: str):
                        .replace(" ", ""))
 
     if '/' in equation:
-    	raise ValueError("Unexpected character '/'. Use decimals and not fractions.")
+        raise ValueError("Unexpected character '/'. Use decimals and not fractions.")
     
     # Check if equation is in form of y = mx + b or y = b + mx
-    match = re.match(r"y=(-?\d*\.?\d*)\*?x([+-]\d+\.?\d*)?|y=([+-]?\d+\.?\d*)([+-]\d*\.?\d*)\*?x", equation)
+    match = re.match(r"y=([-+]?\d*\.?\d*)\*?x([-+]\d*\.?\d*)?|y=([-+]?\d*\.?\d*)([-+]\d*\.?\d*)\*?x?", equation)
     if match:
-        slope = float(match.group(1) or match.group(4) or '1')  # Default slope is 1 if not specified
-        intercept = float(match.group(2) or match.group(3) or '0')  # Default intercept is 0 if not specified
-        #return Affine(intercept, slope)
+        if match.group(1) is not None and match.group(1) != '':
+            slope = float(match.group(1) if match.group(1) != '-' else -1)
+            intercept = float(match.group(2) if match.group(2) not in (None, '', '+', '-') else '0')
+        else:
+            slope = float(match.group(4) if match.group(4) not in (None, '', '+', '-') else '1')
+            intercept = float(match.group(3) if match.group(3) not in (None, '', '+', '-') else '0')
         return intercept, slope
 
     # Check if equation is in form of x = my + b or x = b + my
-    match = re.match(r"x=(-?\d*\.?\d*)\*?y([+-]\d+\.?\d*)?|x=([+-]?\d+\.?\d*)([+-]\d*\.?\d*)\*?y", equation)
+    match = re.match(r"x=([-+]?\d*\.?\d*)\*?y([-+]\d*\.?\d*)?|x=([-+]?\d*\.?\d*)([-+]\d*\.?\d*)\*?y?", equation)
     if match:
-        slope = float(match.group(1) or match.group(4) or '1')  # Default slope is 1 if not specified
-        intercept = float(match.group(2) or match.group(3) or '0')  # Default intercept is 0 if not specified
-        #return Affine(intercept, 1 / slope)  # Inverting the slope for this case
-        return -intercept/slope, 1/slope
+        if match.group(1) is not None and match.group(1) != '':
+            slope = float(match.group(1) if match.group(1) != '-' else -1)
+            intercept = float(match.group(2) if match.group(2) not in (None, '', '+', '-') else '0')
+        else:
+            slope = float(match.group(4) if match.group(4) not in (None, '', '+', '-') else '1')
+            intercept = float(match.group(3) if match.group(3) not in (None, '', '+', '-') else '0')
+        return -intercept / slope, 1 / slope
+    
     raise ValueError("Invalid equation")

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -8,7 +8,7 @@ class TestFormula(unittest.TestCase):
         s2 = 'P = 10 - 2Q'
         s3 = 'p = 2 + 4*q'
         s4 = 'y = 1*x'
-        s5 = 'x = 2x'
+        s5 = 'x = 2y'
         s6 = 'y=x'
 
         self.affine1 = _formula(s1)

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -7,14 +7,27 @@ class TestFormula(unittest.TestCase):
         s1 = 'P = 10 - 2*Q'
         s2 = 'P = 10 - 2Q'
         s3 = 'p = 2 + 4*q'
+        s4 = 'y = 1*x'
+        s5 = 'x = 2x'
+        s6 = 'y=x'
+
         self.affine1 = _formula(s1)
         self.affine2 = _formula(s2)
         self.affine3 = _formula(s3)
+        self.affine4 = _formula(s4)
+        self.affine5 = _formula(s5)
+        self.affine6 = _formula(s6)
 
-    def test_slope(self):
+    def test_coef(self):
 
         self.assertTrue(self.affine1[1] == self.affine2[1] == -2)
         self.assertTrue(self.affine3[1] == 4)
+        self.assertTrue(self.affine4[0] == 0)
+        self.assertTrue(self.affine4[1] == 1)
+        self.assertTrue(self.affine5[0] == 0)
+        self.assertTrue(self.affine5[1] == 0.5)
+        self.assertTrue(self.affine6[0] == 0)
+        self.assertTrue(self.affine6[1] == 1)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
# Changes

Formerly, `_formula` would not be able to parse a formula like `'y = 1 + x'` and `y = 1 + 1*x'` would be necessary. This updates _formula and the corresponding tests. 