### PR TITLE
Rename test method for shifts

### DIFF
--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -22,7 +22,7 @@ class TestDemand(unittest.TestCase):
         self.d1 = Demand(12,-2)
         self.d2 = Demand.from_formula('p = 12 - q')
 
-    def shifts(self):
+    def test_shifts(self):
 
         new_d = self.d1.vertical_shift(1, inplace=False)
         self.assertTrue(new_d.p(0) == 13)


### PR DESCRIPTION
## Summary
- rename the `shifts` test in `tests/test_curves.py` to `test_shifts`

## Testing
- `python -m unittest discover` *(fails: ModuleNotFoundError: No module named 'numpy')*