### PR TITLE
Add auction edge case tests

### DIFF
--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -1,4 +1,8 @@
 import unittest
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
 from freeride.double_auction import UnitAgent, UnitDemand, UnitSupply, DoubleAuction
 
 class TestDoubleAuction(unittest.TestCase):
@@ -27,3 +31,59 @@ class TestDoubleAuction(unittest.TestCase):
         
     def tearDown(self):
         pass
+
+
+class TestDoubleAuctionAdditional(unittest.TestCase):
+    """Additional tests for the double auction implementation."""
+
+    def test_multiple_units(self):
+        """Auction should handle multiple demand and supply units."""
+
+        agents = [
+            UnitDemand(9),
+            UnitDemand(8),
+            UnitSupply(5),
+            UnitSupply(4),
+        ]
+        auction = DoubleAuction(*agents)
+        price_low, price_high = auction.p
+
+        self.assertEqual(auction.q, 2)
+        self.assertEqual(price_low, 5)
+        self.assertEqual(price_high, 8)
+
+    def test_empty_demand_raises(self):
+        """An auction with no demand should raise ``IndexError``."""
+
+        with self.assertRaises(IndexError):
+            DoubleAuction(UnitSupply(4), UnitSupply(5))
+
+    def test_empty_supply_raises(self):
+        """An auction with no supply should raise ``IndexError``."""
+
+        with self.assertRaises(IndexError):
+            DoubleAuction(UnitDemand(9), UnitDemand(8))
+
+    def test_plot_returns_axes(self):
+        """The ``plot`` method should return a Matplotlib ``Axes`` object."""
+
+        agents = [UnitDemand(9), UnitSupply(4)]
+        auction = DoubleAuction(*agents)
+        ax = auction.plot()
+        self.assertIsInstance(ax, plt.Axes)
+
+    def test_clearing_price_correctness(self):
+        """Verify the clearing price range for a known configuration."""
+
+        agents = [
+            UnitDemand(10),
+            UnitDemand(9),
+            UnitDemand(5),
+            UnitSupply(6),
+            UnitSupply(4),
+        ]
+        auction = DoubleAuction(*agents)
+        self.assertEqual(auction.q, 2)
+        self.assertEqual(auction.p, (6, 9))
+
+


### PR DESCRIPTION
## Summary
- add new tests for auction scenarios
  - multi-unit agents
  - empty demand/supply
  - clearing price check
  - plotting with Agg backend

## Testing
- `pytest -q`