### PR TITLE
Add TeX highlighting option for Game tables

### DIFF
--- a/docs/games.rst
+++ b/docs/games.rst
@@ -5,3 +5,22 @@ Games
     :members:
     :undoc-members:
     :show-inheritance:
+
+Highlighting Options
+--------------------
+
+``Game.table`` accepts a ``usetex`` argument. When set to ``True`` the
+underlying text is rendered with LaTeX and best responses are underlined.  When
+``False`` (the default), best responses are indicated with colored boxes and no
+raw ``\underline`` appears in the output.
+
+Example::
+
+    import matplotlib.pyplot as plt
+    from freeride.games import Game
+
+    p1 = [[3, 0], [5, 1]]
+    p2 = [[3, 5], [0, 1]]
+    g = Game(p1, p2)
+    ax = g.table(usetex=False)
+    plt.close(ax.figure)

--- a/freeride/games.py
+++ b/freeride/games.py
@@ -153,6 +153,7 @@ class Game:
         show_solution: bool = True,
         player_names: Sequence[str] = ("Player A", "Player B"),
         action_names: Sequence[Sequence[str]] = (("action 0", "action 1"), ("action 0", "action 1")),
+        usetex: bool = False,
     ) -> plt.Axes:
         """Plot a 2x2 payoff table.
 
@@ -167,6 +168,10 @@ class Game:
         action_names : sequence of sequence of str, optional
             ``action_names[0]`` are actions for player A and ``action_names[1]``
             for player B.
+        usetex : bool, default ``False``
+            Use LaTeX for text rendering and underline best responses when
+            ``True``. When ``False``, best responses are highlighted with colored
+            boxes.
 
         Returns
         -------
@@ -183,6 +188,10 @@ class Game:
 
         if ax is None:
             ax = plt.gca()
+
+        prev = plt.rcParams.get("text.usetex", False)
+        if usetex:
+            plt.rcParams["text.usetex"] = True
 
         for i in range(2):
             for j in range(2):
@@ -205,21 +214,37 @@ class Game:
                 s1, s2 = str(p1), str(p2)
                 bbox = None
                 if show_solution:
-                    if a_is_br:
-                        s1 = r"\underline{" + s1 + r"}"
-                    if b_is_br:
-                        s2 = r"\underline{" + s2 + r"}"
-                    if a_is_br and b_is_br:
-                        bbox = dict(
-                            facecolor="lightyellow",
-                            edgecolor="black",
-                            alpha=0.85,
-                        )
+                    if usetex:
+                        if a_is_br:
+                            s1 = r"\underline{" + s1 + r"}"
+                        if b_is_br:
+                            s2 = r"\underline{" + s2 + r"}"
+                        if a_is_br and b_is_br:
+                            bbox = dict(
+                                facecolor="lightyellow",
+                                edgecolor="black",
+                                alpha=0.85,
+                            )
+                    else:
+                        if a_is_br and b_is_br:
+                            bbox = dict(
+                                facecolor="lightyellow",
+                                edgecolor="black",
+                                alpha=0.85,
+                            )
+                        elif a_is_br:
+                            bbox = dict(facecolor="lightblue", edgecolor="none", alpha=0.5)
+                        elif b_is_br:
+                            bbox = dict(facecolor="lightgreen", edgecolor="none", alpha=0.5)
+
+                text = f"{s1}, {s2}"
+                if usetex:
+                    text = f"${s1}$, ${s2}$"
 
                 ax.text(
                     j - 0.5,
                     -i - 0.5,
-                    f"{s1}, {s2}",
+                    text,
                     va="center",
                     ha="center",
                     size=12,
@@ -297,6 +322,9 @@ class Game:
         )
 
         ax.axis("off")
+
+        # Restore previous TeX setting
+        plt.rcParams["text.usetex"] = prev
 
         return ax
 

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -68,6 +68,26 @@ class TestGame(unittest.TestCase):
         ax = game.table()
         self.assertIsInstance(ax, plt.Axes)
 
+    def test_no_raw_underline_without_tex(self):
+        r"""Ensure ``\underline`` is not used when ``usetex=False``."""
+
+        p1 = [[3, 0], [5, 1]]
+        p2 = [[3, 5], [0, 1]]
+        game = Game(p1, p2)
+        ax = game.table(usetex=False)
+        texts = [t.get_text() for t in ax.texts]
+        self.assertFalse(any("\\underline" in t for t in texts))
+
+    def test_tex_highlighting(self):
+        r"""Best response highlighting works with ``usetex=True``."""
+
+        p1 = [[3, 0], [5, 1]]
+        p2 = [[3, 5], [0, 1]]
+        game = Game(p1, p2)
+        ax = game.table(usetex=True)
+        texts = [t.get_text() for t in ax.texts]
+        self.assertTrue(any("\\underline" in t for t in texts))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow LaTeX rendering in `Game.table` via new `usetex` parameter
- document how to highlight best responses with and without LaTeX
- test new highlighting behaviour

## Testing
- `pytest -q`