### PR TITLE
Enhance PPF class

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -883,6 +883,36 @@ class PPF(BaseAffine):
         elements = self.elements + other.elements
         return type(self)(elements=elements)
 
+    def __call__(self, x):
+        """Return the quantity of the second good for ``x`` units of the first."""
+        for piece in self.pieces:
+            if piece:
+                a, b = piece._domain
+                if (a <= x <= b) or (a >= x >= b):
+                    return piece(x)
+        return np.nan
+
+    def horizontal_shift(self, delta, inplace=True):
+        new_elements = [e.horizontal_shift(delta, inplace=False) for e in self.elements]
+        if inplace:
+            self.__init__(elements=new_elements)
+            return self
+        return type(self)(elements=new_elements)
+
+    def vertical_shift(self, delta, inplace=True):
+        new_elements = [e.vertical_shift(delta, inplace=False) for e in self.elements]
+        if inplace:
+            self.__init__(elements=new_elements)
+            return self
+        return type(self)(elements=new_elements)
+
+    def __mul__(self, scalar):
+        elements = [e * scalar for e in self.elements]
+        return type(self)(elements=elements)
+
+    def __rmul__(self, scalar):
+        return self.__mul__(scalar)
+
     def plot(self, ax=None, set_lims=True, max_q=None, label=True, backend='mpl', **kwargs):
         '''
         Plot the ppf.

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -5,6 +5,7 @@ from freeride.curves import (
     BaseAffine,
     Demand,
     Supply,
+    PPF,
     intersection,
     blind_sum,
     horizontal_sum,
@@ -127,3 +128,23 @@ class TestCurveEdgeCases(unittest.TestCase):
         inelastic = AffineElement(5, 0, inverse=False)  # perfectly inelastic
         with self.assertRaises(Exception):
             horizontal_sum(inelastic)
+
+
+class TestPPF(unittest.TestCase):
+
+    def setUp(self):
+        self.ppf = PPF(10, -1)
+
+    def test_call(self):
+        self.assertAlmostEqual(self.ppf(5), 5)
+        self.assertTrue(np.isnan(self.ppf(12)))
+
+    def test_shifts_return_type(self):
+        shifted = self.ppf.horizontal_shift(2, inplace=False)
+        self.assertIsInstance(shifted, PPF)
+        shifted_v = self.ppf.vertical_shift(1, inplace=False)
+        self.assertIsInstance(shifted_v, PPF)
+
+    def test_scalar_multiplication(self):
+        scaled = 2 * self.ppf
+        self.assertIsInstance(scaled, PPF)


### PR DESCRIPTION
## Summary
- extend `PPF` with call, shift and scaling helpers
- ensure returned types stay as `PPF`
- test `PPF` call behavior, shift helpers and scalar multiplication

## Testing
- `pytest -q`