### PR TITLE
Add long-run competitive equilibrium class

### DIFF
--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -633,3 +633,45 @@ class Market(Equilibrium):
             world_price=world_price,
             tariff=tariff
         )
+
+
+class LongRunCompetitiveEquilibrium:
+    """Long-run perfectly competitive equilibrium with identical firms."""
+
+    def __init__(self, demand: Demand, total_cost):
+        """Compute long-run equilibrium for a competitive market."""
+        self.total_cost = total_cost
+        self.demand = demand
+
+        # In long-run competitive equilibrium price equals breakeven price.
+        self.p = self.total_cost.breakeven_price()
+
+        # Quantity each firm produces at the breakeven price.
+        self.firm_q = self.total_cost.efficient_scale()
+
+        # Total quantity demanded at the equilibrium price.
+        self.market_q = self.demand.q(self.p)
+
+        # Number of identical firms in the market.
+        self.n_firms = self.market_q / self.firm_q
+
+    def plot(self, fig=None):
+        """Plot firm and market diagrams side by side."""
+
+        if fig is None:
+            fig = plt.gcf()
+
+        firm_ax = fig.add_subplot(1, 2, 1)
+        self.total_cost.long_run_plot(firm_ax)
+        firm_ax.set_title("Firm")
+
+        mkt_ax = fig.add_subplot(1, 2, 2, sharey=firm_ax)
+        supply_curve = Supply(self.p, 0)
+        market_eq = Equilibrium(self.demand, supply_curve)
+        market_eq.plot(mkt_ax)
+        mkt_ax.set_title("Market")
+
+        firm_ax.set_xlabel("Firm Quantity")
+        mkt_ax.set_xlabel("Market Quantity")
+
+        return fig

--- a/tests/test_longrun.py
+++ b/tests/test_longrun.py
@@ -1,0 +1,23 @@
+import unittest
+
+import matplotlib
+matplotlib.use("Agg")
+
+from freeride.curves import Demand
+from freeride.costs import Cost
+from freeride.equilibrium import LongRunCompetitiveEquilibrium
+
+
+class TestLongRunCompetitiveEquilibrium(unittest.TestCase):
+    def test_basic_attributes(self):
+        demand = Demand(10, -1)
+        cost = Cost(1, 0, 1)
+        lr = LongRunCompetitiveEquilibrium(demand, cost)
+        self.assertAlmostEqual(lr.p, 2.0)
+        self.assertAlmostEqual(lr.firm_q, 1.0)
+        self.assertAlmostEqual(lr.market_q, 8.0)
+        self.assertAlmostEqual(lr.n_firms, 8.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `LongRunCompetitiveEquilibrium` for competitive markets
- add unit tests for the new class

## Testing
- `pytest -q`