### PR TITLE
Add helper classmethods for common games

### DIFF
--- a/freeride/__init__.py
+++ b/freeride/__init__.py
@@ -2,7 +2,10 @@
 __version__ = '0.0.7'
 
 from .exceptions import FreeRideError, FormulaParseError
-from .games import Game, NormalFormGame
+from .games import (
+    Game,
+    NormalFormGame,
+)
 
 __all__ = [
     "FreeRideError",

--- a/freeride/games.py
+++ b/freeride/games.py
@@ -328,6 +328,55 @@ class Game:
 
         return ax
 
+    @classmethod
+    def prisoners_dilemma(cls) -> "Game":
+        """Return the classic Prisoner's Dilemma game."""
+
+        p1 = [[3, 0], [5, 1]]
+        p2 = [[3, 5], [0, 1]]
+        return cls(p1, p2)
+
+    @classmethod
+    def matching_pennies(cls) -> "Game":
+        """Return the Matching Pennies game."""
+
+        p1 = [[1, -1], [-1, 1]]
+        p2 = [[-1, 1], [1, -1]]
+        return cls(p1, p2)
+
+    @classmethod
+    def stag_hunt(cls) -> "Game":
+        """Return the Stag Hunt coordination game."""
+
+        p1 = [[2, 0], [1, 1]]
+        p2 = [[2, 1], [0, 1]]
+        return cls(p1, p2)
+
+    @classmethod
+    def battle_of_the_sexes(cls) -> "Game":
+        """Return the Battle of the Sexes coordination game."""
+
+        p1 = [[2, 0], [0, 1]]
+        p2 = [[1, 0], [0, 2]]
+        return cls(p1, p2)
+
+    @classmethod
+    def pure_coordination(cls) -> "Game":
+        """Return a simple pure coordination game."""
+
+        p1 = [[1, 0], [0, 1]]
+        p2 = [[1, 0], [0, 1]]
+        return cls(p1, p2)
+
+    @classmethod
+    def chicken(cls) -> "Game":
+        """Return the classic Chicken (Hawk-Dove) game."""
+
+        p1 = [[3, 1], [4, 0]]
+        p2 = [[3, 4], [1, 0]]
+        return cls(p1, p2)
+
 
 # Backwards compatibility
 NormalFormGame = Game
+

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -88,6 +88,17 @@ class TestGame(unittest.TestCase):
         texts = [t.get_text() for t in ax.texts]
         self.assertTrue(any("\\underline" in t for t in texts))
 
+    def test_class_helpers(self):
+        """Class helper methods should build the expected games."""
+
+        g = Game.prisoners_dilemma()
+        self.assertEqual(g.payoffs1.tolist(), [[3, 0], [5, 1]])
+        self.assertEqual(g.payoffs2.tolist(), [[3, 5], [0, 1]])
+
+        mp = Game.matching_pennies()
+        self.assertEqual(mp.payoffs1.tolist(), [[1, -1], [-1, 1]])
+        self.assertEqual(mp.payoffs2.tolist(), [[-1, 1], [1, -1]])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- convert classic game helpers into class methods on `Game`
- stop exporting the helpers from the package
- test the new helper methods

## Testing
- `pytest -q tests/test_games.py`
- `pytest -q`
