### PR TITLE
Improve games docs with battle of the sexes example

### DIFF
--- a/docs/battle_of_the_sexes.svg
+++ b/docs/battle_of_the_sexes.svg
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="345.6pt" viewBox="0 0 460.8 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-05-24T21:11:29.757640</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 345.6 
+L 460.8 345.6 
+L 460.8 0 
+L 0 0 
+L 0 345.6 
+z
+" style="fill: none"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 236.16 47.808 
+L 109.44 47.808 
+L 109.44 174.528 
+L 236.16 174.528 
+z
+" clip-path="url(#p9b2f488e12)" style="fill: #ffffff; stroke: #000000; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 362.88 47.808 
+L 236.16 47.808 
+L 236.16 174.528 
+L 362.88 174.528 
+z
+" clip-path="url(#p9b2f488e12)" style="fill: #ffffff; stroke: #000000; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 236.16 174.528 
+L 109.44 174.528 
+L 109.44 301.248 
+L 236.16 301.248 
+z
+" clip-path="url(#p9b2f488e12)" style="fill: #ffffff; stroke: #000000; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 362.88 174.528 
+L 236.16 174.528 
+L 236.16 301.248 
+L 362.88 301.248 
+z
+" clip-path="url(#p9b2f488e12)" style="fill: #ffffff; stroke: #000000; stroke-width: 2; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_1">
+    <g id="patch_6">
+     <path d="M 145.9425 120.934875 
+L 199.6575 120.934875 
+L 199.6575 101.401125 
+L 145.9425 101.401125 
+z
+" style="fill: #ffffe0; opacity: 0.85; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <!-- 2.0, 1.0 -->
+    <g transform="translate(149.9025 114.47925) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2e" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-32"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.820312 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(222.607422 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(286.230469 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(318.017578 0)"/>
+    </g>
+   </g>
+   <g id="text_2">
+    <!-- 0.0, 0.0 -->
+    <g transform="translate(276.6225 114.47925) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.820312 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.607422 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(286.230469 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(318.017578 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- 0.0, 0.0 -->
+    <g transform="translate(149.9025 241.19925) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-30"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.820312 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(222.607422 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(286.230469 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(318.017578 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <g id="patch_7">
+     <path d="M 272.6625 247.654875 
+L 326.3775 247.654875 
+L 326.3775 228.121125 
+L 272.6625 228.121125 
+z
+" style="fill: #ffffe0; opacity: 0.85; stroke: #000000; stroke-linejoin: miter"/>
+    </g>
+    <!-- 1.0, 2.0 -->
+    <g transform="translate(276.6225 241.19925) scale(0.12 -0.12)">
+     <use xlink:href="#DejaVuSans-31"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(63.623047 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(95.410156 0)"/>
+     <use xlink:href="#DejaVuSans-2c" transform="translate(159.033203 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(190.820312 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.607422 0)"/>
+     <use xlink:href="#DejaVuSans-2e" transform="translate(286.230469 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(318.017578 0)"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <!-- Player A -->
+    <g transform="translate(79.319415 199.2105) rotate(-90) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-50" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-41" d="M 2188 4044 
+L 1331 1722 
+L 3047 1722 
+L 2188 4044 
+z
+M 1831 4666 
+L 2547 4666 
+L 4325 0 
+L 3669 0 
+L 3244 1197 
+L 1141 1197 
+L 716 0 
+L 50 0 
+L 1831 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-50"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(60.302734 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(88.085938 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(149.365234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(208.544922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(270.068359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(311.181641 0)"/>
+     <use xlink:href="#DejaVuSans-41" transform="translate(342.96875 0)"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <!-- action 1 -->
+    <g transform="translate(101.024312 261.216937) rotate(-90) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-61"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(116.259766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(155.46875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(183.251953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(244.433594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(307.8125 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(339.599609 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- action 0 -->
+    <g transform="translate(101.024312 128.160937) rotate(-90) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-61"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(116.259766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(155.46875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(183.251953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(244.433594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(307.8125 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(339.599609 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- Player B -->
+    <g transform="translate(211.465313 17.687415) scale(0.12 -0.12)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-50"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(60.302734 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(88.085938 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(149.365234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(208.544922 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(270.068359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(311.181641 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(342.96875 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- action 1 -->
+    <g transform="translate(282.527062 39.392313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-61"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(116.259766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(155.46875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(183.251953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(244.433594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(307.8125 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(339.599609 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- action 0 -->
+    <g transform="translate(149.471063 39.392313) scale(0.1 -0.1)">
+     <use xlink:href="#DejaVuSans-61"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(61.279297 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(116.259766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(155.46875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(183.251953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(244.433594 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(307.8125 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(339.599609 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p9b2f488e12">
+   <rect x="103.104" y="41.472" width="266.112" height="266.112"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/games.rst
+++ b/docs/games.rst
@@ -24,3 +24,27 @@ Example::
     g = Game(p1, p2)
     ax = g.table(usetex=False)
     plt.close(ax.figure)
+
+Battle of the Sexes Example
+---------------------------
+
+``Game`` comes with constructors for common games.  The ``battle_of_the_sexes``
+method returns the classic coordination game with players ``Anna`` and ``Boris``
+and actions ``Opera`` and ``Boxing Match`` already labeled.  The table below was
+created with ``usetex=False`` so that best responses are highlighted with
+colored boxes.
+
+In this version, Boris prefers the boxing match while Anna prefers the opera.
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+    from freeride.games import Game
+
+    game = Game.battle_of_the_sexes()
+    ax = game.table(usetex=False)
+    plt.savefig("battle_of_the_sexes.svg", transparent=True)
+
+.. image:: battle_of_the_sexes.svg
+   :align: center
+   :alt: Battle of the Sexes payoff table

--- a/freeride/games.py
+++ b/freeride/games.py
@@ -16,9 +16,24 @@ class Game:
         Payoff matrix for player 2 with the same shape as ``payoffs1``.
     """
 
-    def __init__(self, payoffs1, payoffs2):
+    def __init__(
+        self,
+        payoffs1,
+        payoffs2,
+        *,
+        player_names: Sequence[str] = ("Player A", "Player B"),
+        action_names: Sequence[Sequence[str]] = (
+            ("action 0", "action 1"),
+            ("action 0", "action 1"),
+        ),
+    ):
         self.payoffs1 = np.asarray(payoffs1, dtype=float)
         self.payoffs2 = np.asarray(payoffs2, dtype=float)
+        self.player_names = tuple(player_names)
+        self.action_names = (
+            tuple(action_names[0]),
+            tuple(action_names[1]),
+        )
 
         if self.payoffs1.shape != self.payoffs2.shape:
             raise ValueError("Payoff matrices must have the same shape")
@@ -151,8 +166,8 @@ class Game:
         self,
         ax: Optional[plt.Axes] = None,
         show_solution: bool = True,
-        player_names: Sequence[str] = ("Player A", "Player B"),
-        action_names: Sequence[Sequence[str]] = (("action 0", "action 1"), ("action 0", "action 1")),
+        player_names: Optional[Sequence[str]] = None,
+        action_names: Optional[Sequence[Sequence[str]]] = None,
         usetex: bool = False,
     ) -> plt.Axes:
         """Plot a 2x2 payoff table.
@@ -164,10 +179,11 @@ class Game:
         show_solution : bool, default ``True``
             Highlight best responses and Nash equilibria when ``True``.
         player_names : sequence of str, optional
-            Names for the row and column players.
+            Names for the row and column players.  Defaults to the names stored
+            on the ``Game`` instance.
         action_names : sequence of sequence of str, optional
             ``action_names[0]`` are actions for player A and ``action_names[1]``
-            for player B.
+            for player B. Defaults to the names stored on the ``Game`` instance.
         usetex : bool, default ``False``
             Use LaTeX for text rendering and underline best responses when
             ``True``. When ``False``, best responses are highlighted with colored
@@ -188,6 +204,11 @@ class Game:
 
         if ax is None:
             ax = plt.gca()
+
+        if player_names is None:
+            player_names = self.player_names
+        if action_names is None:
+            action_names = self.action_names
 
         prev = plt.rcParams.get("text.usetex", False)
         if usetex:
@@ -358,7 +379,12 @@ class Game:
 
         p1 = [[2, 0], [0, 1]]
         p2 = [[1, 0], [0, 2]]
-        return cls(p1, p2)
+        return cls(
+            p1,
+            p2,
+            player_names=("Anna", "Boris"),
+            action_names=(("Opera", "Boxing Match"), ("Opera", "Boxing Match")),
+        )
 
     @classmethod
     def pure_coordination(cls) -> "Game":

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -99,6 +99,15 @@ class TestGame(unittest.TestCase):
         self.assertEqual(mp.payoffs1.tolist(), [[1, -1], [-1, 1]])
         self.assertEqual(mp.payoffs2.tolist(), [[-1, 1], [1, -1]])
 
+        bos = Game.battle_of_the_sexes()
+        self.assertEqual(bos.payoffs1.tolist(), [[2, 0], [0, 1]])
+        self.assertEqual(bos.payoffs2.tolist(), [[1, 0], [0, 2]])
+        self.assertEqual(bos.player_names, ("Anna", "Boris"))
+        self.assertEqual(
+            bos.action_names,
+            (("Opera", "Boxing Match"), ("Opera", "Boxing Match")),
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- document colored-box table highlighting for `Game.table`
- add a Battle of the Sexes example and embed an image of the payoff table
- have `Game.battle_of_the_sexes` return a game labeled with Anna/Boris and Opera/Boxing Match defaults
- use stored defaults for names in `Game.table`
- test the new defaults

## Testing
- `pytest -q`
