### PR TITLE
Add slope validation for PPF

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -876,7 +876,14 @@ class PPF(BaseAffine):
             If the lengths of `slope` and `intercept` do not match.
         '''
         super().__init__(intercept, slope, elements, inverse)
+        self._check_slope()
         self.pieces = ppf_sum(*self.elements)
+
+
+    def _check_slope(self):
+        for slope in self.slope:
+            if slope >= 0:
+                raise Exception("Upward-sloping PPF.")
 
 
     def __add__(self, other):

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -129,6 +129,10 @@ class TestCurveEdgeCases(unittest.TestCase):
         with self.assertRaises(Exception):
             horizontal_sum(inelastic)
 
+    def test_upward_sloping_ppf_raises(self):
+        with self.assertRaises(Exception):
+            PPF(10, 1)
+
 
 class TestPPF(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- validate PPF slope sign on construction
- test that upward‐sloping PPF raises an exception

## Testing
- `pytest -q`