### PR TITLE
Fix PPF scaling

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -907,8 +907,17 @@ class PPF(BaseAffine):
         return type(self)(elements=new_elements)
 
     def __mul__(self, scalar):
-        elements = [e * scalar for e in self.elements]
-        return type(self)(elements=elements)
+        new_elements = []
+        for e in self.elements:
+            new_intercept = scalar * e.intercept
+            new_el = AffineElement(
+                intercept=new_intercept,
+                slope=e.slope,
+                inverse=True,
+                symbols=e.symbols,
+            )
+            new_elements.append(new_el)
+        return type(self)(elements=new_elements)
 
     def __rmul__(self, scalar):
         return self.__mul__(scalar)

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -148,3 +148,6 @@ class TestPPF(unittest.TestCase):
     def test_scalar_multiplication(self):
         scaled = 2 * self.ppf
         self.assertIsInstance(scaled, PPF)
+        self.assertEqual(scaled.intercept, [2 * self.ppf.intercept[0]])
+        self.assertEqual(scaled.slope, self.ppf.slope)
+        self.assertAlmostEqual(scaled.q_intercept, 2 * self.ppf.q_intercept)


### PR DESCRIPTION
## Summary
- modify `PPF.__mul__` and `__rmul__` to scale intercepts not slopes
- verify scaled intercepts and slopes in tests

## Testing
- `pytest -q`
- `pytest tests/test_curves.py::TestPPF::test_scalar_multiplication -q`
