### PR TITLE
Fix Demand shift return types

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -365,14 +365,14 @@ class BaseAffine:
         if inplace:
             self.__init__(elements=new_elements)
         else:
-            return Affine(elements=new_elements)
+            return type(self)(elements=new_elements)
 
     def vertical_shift(self, delta, inplace=True):
         new_elements = [e.vertical_shift(delta, inplace=False) for e in self.elements]
         if inplace:
             self.__init__(elements=new_elements)
         else:
-            return Affine(elements=new_elements)
+            return type(self)(elements=new_elements)
 
     @property
     def q_intercept(self):

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -56,6 +56,13 @@ class TestDemand(unittest.TestCase):
         self.d1.horizontal_shift(1, inplace=True)
         self.assertTrue(self.d1.q(0)==7)
 
+    def test_shift_return_types(self):
+        horiz = self.d1.horizontal_shift(1, inplace=False)
+        self.assertIsInstance(horiz, Demand)
+
+        vert = self.d1.vertical_shift(1, inplace=False)
+        self.assertIsInstance(vert, Demand)
+
 
 class TestCurveHelpers(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- make `BaseAffine.shift` methods return `type(self)` for non-inplace operations
- test that `Demand` shift methods return `Demand`

## Testing
- `pytest -q`