### PR TITLE
Add PPFError exception

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -7,6 +7,7 @@ from freeride.base import PolyBase, QuadraticElement, AffineElement
 from IPython.display import Latex, display
 from bokeh.plotting import figure, show
 from bokeh.models import HoverTool, ColumnDataSource
+from freeride.exceptions import PPFError
 
 
 class BaseQuadratic:
@@ -883,7 +884,7 @@ class PPF(BaseAffine):
     def _check_slope(self):
         for slope in self.slope:
             if slope >= 0:
-                raise Exception("Upward-sloping PPF.")
+                raise PPFError("Upward-sloping PPF.")
 
 
     def __add__(self, other):

--- a/freeride/exceptions.py
+++ b/freeride/exceptions.py
@@ -21,3 +21,7 @@ class FormulaParseError(FreeRideError):
     """Error raised when parsing a formula string fails."""
 
 
+class PPFError(FreeRideError):
+    """Error raised for invalid production possibility frontiers."""
+
+

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -10,6 +10,7 @@ from freeride.curves import (
     blind_sum,
     horizontal_sum,
 )
+from freeride.exceptions import PPFError
 from freeride.base import AffineElement
 
 class TestAffine(unittest.TestCase):
@@ -137,7 +138,7 @@ class TestCurveEdgeCases(unittest.TestCase):
             horizontal_sum(inelastic)
 
     def test_upward_sloping_ppf_raises(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(PPFError):
             PPF(10, 1)
 
 


### PR DESCRIPTION
## Summary
- add new `PPFError` exception type
- raise `PPFError` for non‑negative PPF slopes
- update curve tests to expect `PPFError`

## Testing
- `pytest tests/test_curves.py::TestCurveEdgeCases::test_upward_sloping_ppf_raises -q`
- `pytest -q`