### PR TITLE
Improve formula parsing and add tests

### DIFF
--- a/freeride/formula.py
+++ b/freeride/formula.py
@@ -11,10 +11,11 @@ def _formula(equation: str):
     """
     Parse a linear equation string and return an Affine object.
 
-    Accepts equations in forms like 'y = mx + b', 'y = b + mx',
-    'x = my + b', and 'x = b + my'. Variables 'y' and 'x' can be
-    'p', 'P', 'q', or 'Q'. Handles optional whitespaces, signs for
-    coefficients, and decimal coefficients.
+    Accepts linear equations in a variety of notations including
+    ``y = mx + b``, ``x = my + b`` and the implicit form
+    ``ax + by = c``. Coefficients may appear with or without an
+    explicit ``*`` (e.g. ``2x`` or ``2*x``) and variables may also be
+    written as ``p``/``q``.  Whitespaces are ignored.
 
     Parameters
     ----------
@@ -29,7 +30,7 @@ def _formula(equation: str):
     Raises
     ------
     FormulaParseError
-        If the equation is not valid, contains fractions, or has a zero slope.
+        If the equation is not valid or contains fractions.
 
     Examples
     --------
@@ -40,7 +41,8 @@ def _formula(equation: str):
     >>> _formula('P=3+0.5Q')
     (3.0, 0.5)
     """
-    # Remove whitespaces and equate p with y and q with x
+    # Normalize string: remove whitespace, convert to lowercase and unify
+    # variable names so both ``p``/``q`` and ``y``/``x`` are accepted.
     equation = (
         equation.lower().replace("p", "y").replace("q", "x").replace(" ", "")
     )
@@ -50,61 +52,60 @@ def _formula(equation: str):
             "Unexpected character '/'. Use decimals and not fractions."
         )
 
-    # Check if equation is in form of y = mx + b or y = b + mx
-    pattern_y = (
-        r"y=([-+]?\d*\.?\d*)\*?x([-+]\d*\.?\d*)?"
-        r"|y=([-+]?\d*\.?\d*)([-+]\d*\.?\d*)\*?x?"
-    )
-    match = re.match(pattern_y, equation)
-    if match:
-        if match.group(1) is not None and match.group(1) != "":
-            slope = float(match.group(1) if match.group(1) != "-" else -1)
-            intercept = float(
-                match.group(2)
-                if match.group(2) not in (None, "", "+", "-")
-                else "0"
-            )
-        else:
-            slope = float(
-                match.group(4)
-                if match.group(4) not in (None, "", "+", "-")
-                else "1"
-            )
-            intercept = float(
-                match.group(3)
-                if match.group(3) not in (None, "", "+", "-")
-                else "0"
-            )
-        return intercept, slope
+    # Insert missing multiplication symbols so ``2x`` becomes ``2*x`` and
+    # ``x*2`` becomes ``2*x`` for easier evaluation.
+    equation = re.sub(r"(?<=\d)(?=[xy])", "*", equation)
+    equation = re.sub(r"([xy])(?=\d)", r"\1*", equation)
+    equation = re.sub(r"([xy])\*([-+]?\d*\.?\d+)", r"\2*\1", equation)
 
-    # Check if equation is in form of x = my + b or x = b + my
-    pattern_x = (
-        r"x=([-+]?\d*\.?\d*)\*?y([-+]\d*\.?\d*)?"
-        r"|x=([-+]?\d*\.?\d*)([-+]\d*\.?\d*)\*?y?"
-    )
-    match = re.match(pattern_x, equation)
-    if match:
-        if match.group(1) is not None and match.group(1) != "":
-            slope = float(match.group(1) if match.group(1) != "-" else -1)
-            intercept = float(
-                match.group(2)
-                if match.group(2) not in (None, "", "+", "-")
-                else "0"
-            )
-        else:
-            slope = float(
-                match.group(4)
-                if match.group(4) not in (None, "", "+", "-")
-                else "1"
-            )
-            intercept = float(
-                match.group(3)
-                if match.group(3) not in (None, "", "+", "-")
-                else "0"
-            )
-        return -intercept / slope, 1 / slope
+    if any(t in equation for t in ("x*y", "y*x", "x*x", "y*y", "**")):
+        raise FormulaParseError("Equation must be affine")
 
-    raise FormulaParseError("Invalid equation")
+    if equation.count("=") != 1:
+        raise FormulaParseError("Equation must contain exactly one '=' sign")
+
+    lhs, rhs = equation.split("=")
+
+    def _safe_eval(expr: str, **values: float) -> float:
+        if not re.fullmatch(r"[0-9xy+\-*.()]+", expr):
+            raise FormulaParseError("Invalid characters in equation")
+        return eval(expr, {"__builtins__": {}}, values)
+
+    # If equation is given explicitly as y = f(x)
+    if lhs == "y" or rhs == "y":
+        expr = rhs if lhs == "y" else lhs
+        if "y" in expr:
+            raise FormulaParseError("y must be expressed solely in terms of x")
+        intercept = _safe_eval(expr, x=0, y=0)
+        y1 = _safe_eval(expr, x=1, y=0)
+        slope = y1 - intercept
+        return float(intercept), float(slope)
+
+    # x = f(y)
+    if lhs == "x" or rhs == "x":
+        expr = rhs if lhs == "x" else lhs
+        if "x" in expr:
+            raise FormulaParseError("x must be expressed solely in terms of y")
+        b = _safe_eval(expr, x=0, y=0)
+        x1 = _safe_eval(expr, x=0, y=1)
+        m = x1 - b
+        if m == 0:
+            raise FormulaParseError("Zero slope invalid for x=f(y)")
+        intercept = -b / m
+        slope = 1 / m
+        return float(intercept), float(slope)
+
+    # General form ax + by = c
+    expr = f"{lhs}-({rhs})"
+    base = _safe_eval(expr, x=0, y=0)
+    a = _safe_eval(expr, x=1, y=0) - base
+    b = _safe_eval(expr, x=0, y=1) - base
+    c = -base
+    if b == 0:
+        raise FormulaParseError("Equation does not define y as a function of x")
+    intercept = c / b
+    slope = -a / b
+    return float(intercept), float(slope)
 
 
 def _quadratic_formula(equation: str):

--- a/tests/test_formula.py
+++ b/tests/test_formula.py
@@ -11,6 +11,10 @@ class TestFormula(unittest.TestCase):
         s4 = 'y = 1*x'
         s5 = 'x = 2y'
         s6 = 'y=x'
+        s7 = 'y = 10 - x'
+        s8 = 'y = 10 - x*2'
+        s9 = 'x + y = 10'
+        s10 = '2x + 3y = 6'
 
         self.affine1 = _formula(s1)
         self.affine2 = _formula(s2)
@@ -18,6 +22,10 @@ class TestFormula(unittest.TestCase):
         self.affine4 = _formula(s4)
         self.affine5 = _formula(s5)
         self.affine6 = _formula(s6)
+        self.affine7 = _formula(s7)
+        self.affine8 = _formula(s8)
+        self.affine9 = _formula(s9)
+        self.affine10 = _formula(s10)
 
     def test_coef(self):
         """Verify both slope and intercept parsing for a variety of forms."""
@@ -29,6 +37,10 @@ class TestFormula(unittest.TestCase):
         self.assertEqual(self.affine4[1], 1)
         self.assertEqual(self.affine5[1], 0.5)
         self.assertEqual(self.affine6[1], 1)
+        self.assertEqual(self.affine7[1], -1)
+        self.assertEqual(self.affine8[1], -2)
+        self.assertEqual(self.affine9[1], -1)
+        self.assertAlmostEqual(self.affine10[1], -2/3)
 
         # Intercepts
         self.assertEqual(self.affine1[0], 10)
@@ -37,6 +49,10 @@ class TestFormula(unittest.TestCase):
         self.assertEqual(self.affine4[0], 0)
         self.assertEqual(self.affine5[0], 0)
         self.assertEqual(self.affine6[0], 0)
+        self.assertEqual(self.affine7[0], 10)
+        self.assertEqual(self.affine8[0], 10)
+        self.assertEqual(self.affine9[0], 10)
+        self.assertEqual(self.affine10[0], 2)
 
     def test_fraction_raises(self):
         """Fractions are not supported and should raise a FormulaParseError."""
@@ -46,7 +62,7 @@ class TestFormula(unittest.TestCase):
     def test_invalid_equation_raises(self):
         """Equations that do not match the expected forms should error."""
         with self.assertRaises(FormulaParseError):
-            _formula("2x + 1 = y")
+            _formula("y = x*y")
 
     def tearDown(self):
         pass


### PR DESCRIPTION
## Summary
- overhaul `_formula` parser to support a wider array of linear forms such as `x+y=c`
- normalise formula strings and safely evaluate coefficients
- reject non‑affine expressions and enforce variable-only rules
- expand unit tests for new behaviours

## Testing
- `pip install -q numpy matplotlib`
- `pytest -q`