### PR TITLE
Add infinite slope check for PPF

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -908,8 +908,8 @@ class PPF(BaseAffine):
 
     def _check_slope(self):
         for slope in self.slope:
-            if slope >= 0:
-                raise PPFError("Upward-sloping PPF.")
+            if slope >= 0 or np.isinf(slope):
+                raise PPFError("Upward-sloping or infinite-slope PPF.")
 
 
     def __add__(self, other):

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -141,6 +141,10 @@ class TestCurveEdgeCases(unittest.TestCase):
         with self.assertRaises(PPFError):
             PPF(10, 1)
 
+    def test_infinite_slope_ppf_raises(self):
+        with self.assertRaises(PPFError):
+            PPF(10, -np.inf)
+
     def test_has_perfect_segment_property(self):
         elastic = BaseAffine(5, 0, inverse=True)
         self.assertTrue(elastic.has_perfectly_elastic_segment)


### PR DESCRIPTION
## Summary
- treat any infinite slope as invalid in `PPF` and raise `PPFError`
- test that creating a PPF with `-np.inf` slope raises the error

## Testing
- `pytest -q`
