### PR TITLE
Improve plot autoscaling

### DIFF
--- a/freeride/base.py
+++ b/freeride/base.py
@@ -188,6 +188,9 @@ class PolyBase(np.polynomial.Polynomial):
         if textbook_style:
             textbook_axes(ax)
 
+        ax.relim()
+        ax.autoscale_view()
+
     # Similar to numpy ABCPolyBase
     def _repr_latex_(self):
         """
@@ -597,9 +600,8 @@ class AffineElement(PolyBase):
             ax.set_ylabel("Price")
             ax.set_xlabel("Quantity")
 
-        # fix lims
-        ylims = ax.get_ylim()
-        ax.set_ylim(0, ylims[1])
+        ax.relim()
+        ax.autoscale_view()
 
         return ax
 
@@ -632,6 +634,9 @@ class AffineElement(PolyBase):
         p01 = self.p(q[0]), self.p(q[1])
 
         ax.fill_between(q, p01, p, zorder=zorder, color=color, alpha=alpha)
+
+        ax.relim()
+        ax.autoscale_view()
 
         return ax
 
@@ -715,6 +720,9 @@ class QuadraticElement(PolyBase):
             # ax.set_ylabel("Price")
             ax.set_xlabel("Quantity")
 
+        ax.relim()
+        ax.autoscale_view()
+
         return ax
 
     def plot_area_below(self, q0, q1, ax=None, zorder=-1, color=None, alpha=None):
@@ -728,6 +736,9 @@ class QuadraticElement(PolyBase):
         ys = self(xs)
         ax.fill_between(xs, 0, ys, zorder=zorder, color=color, alpha=alpha)
 
+        ax.relim()
+        ax.autoscale_view()
+
         return ax
 
     def plot_area_above(self, q0, q1, y, ax=None, zorder=-1, color=None, alpha=None):
@@ -740,6 +751,10 @@ class QuadraticElement(PolyBase):
         xs = np.linspace(q0, q1, 100)
         ys = self(xs)
         ax.fill_between(xs, ys, y, zorder=zorder, color=color, alpha=alpha)
+
+        ax.relim()
+        ax.autoscale_view()
+
         return ax
 
     @classmethod

--- a/freeride/costs.py
+++ b/freeride/costs.py
@@ -339,8 +339,10 @@ class Cost(PolyBase):
         ax.plot([0,q], [p,p], linestyle = 'dashed', color = 'gray')
         ax.plot([q,q], [0,p], linestyle = 'dashed', color = 'gray')
         ax.plot([q], [p], marker = 'o')
-        ax.set_xlim(0,max_q)
-        ax.set_ylim(0,2*p)
+
+        ax.relim()
+        ax.autoscale_view()
+
         ax.legend()
 
     def cost_profit_plot(self, p, ax = None, items = ['tc', 'tr', 'profit']):
@@ -403,8 +405,10 @@ class Cost(PolyBase):
         if 'tr' in items:
             ax.fill_between([0,q], 0, p, facecolor = 'blue', alpha = 0.1, label = 'TR', hatch = '+')
 
+        ax.relim()
+        ax.autoscale_view()
 
-
+        return ax
 
 class AverageCost:
     """
@@ -507,3 +511,8 @@ class AverageCost:
         xs = np.linspace(0.01, max_q, int(10*max_q))
         ys = self(xs)
         ax.plot(xs, ys, label = label)
+
+        ax.relim()
+        ax.autoscale_view()
+
+        return ax

--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -125,6 +125,10 @@ class BaseQuadratic:
             if elmt:
                 elmt.plot(ax=ax, label=label, max_q=max_q, **plot_dict)
 
+        if set_lims:
+            ax.relim()
+            ax.autoscale_view()
+
         return ax
 
     def active_element(self, q):
@@ -644,41 +648,8 @@ class Affine(BaseAffine):
                 piece.plot(ax=ax, label=label, max_q=max_q, **plot_dict)
 
         if set_lims:
-            # Gather current limits
-            ylim = ax.get_ylim()
-            xlim = ax.get_xlim()
-
-            # Build a list of the piecewise domain endpoints
-            flat_q = sorted([qv for seg in self.qsections for qv in seg if np.isfinite(qv)])
-            flat_p = sorted([pv for seg in self.psections for pv in seg if np.isfinite(pv)])
-
-            # If we have no finite domain boundaries, we won't override user-limits
-            if flat_q:
-                # If user didn't specify max_q, pick it from the largest domain endpoint
-                if max_q is None:
-                    possible_max_q = flat_q[-1]
-                    # If it's infinite, skip. If there's only ∞, fallback to 10 or something
-                    if np.isinf(possible_max_q):
-                        possible_max_q = 10.0
-                    max_q = possible_max_q
-            else:
-                # fallback if we have no piecewise domain info
-                if max_q is None:
-                    max_q = 10.0
-
-            # Evaluate the curve at max_q
-            val_at_max_q = safe_eval(max_q)
-
-            # If that fails, fallback to 0
-            if np.isnan(val_at_max_q):
-                val_at_max_q = 0
-
-            # Decide new upper bound for price
-            max_p = max(val_at_max_q, ylim[1], 0)
-            
-            # Only update axes if that doesn't cause error
-            ax.set_ylim(0, max_p)
-            ax.set_xlim(0, max_q)
+            ax.relim()
+            ax.autoscale_view()
 
         # Apply any leftover kwargs that might be e.g. title, xlim, ylim
         for key, value in kwargs.items():
@@ -738,28 +709,8 @@ class Affine(BaseAffine):
 
         # check limits
         if set_lims:
-            ylim = ax.get_ylim()
-            xlim = ax.get_xlim()
-            if ylim[1] <= np.max(self.intercept):
-                ax.set_ylim(0, np.max(self.intercept)*1.01)
-
-            flat_q = sorted([i for tup in self.qsections for i in tup])
-            flat_p = sorted([i for tup in self.psections for i in tup])
-            if max_q is None:
-                if np.inf in flat_q:
-                    max_q = 1.5*flat_q[-2]
-                else:
-                    max_q = flat_q[-1]
-            if np.inf in flat_p:
-                max_p = np.max([self(max_q), 1.5*flat_p[-2]])
-            else:
-                max_p = np.max([self(max_q), 1.5*flat_p[-1]])
-
-            # don't decrease limits relative to starting point
-            ax.set_ylim(0, np.max([max_p, ylim[1]]))
-            ax.set_xlim(0, np.max([max_q, 1, xlim[1]]))
-            # fix for demand and supply and inverse vs q(p)
-            #ax.set_xlim(0, np.max(self.intercept))
+            ax.relim()
+            ax.autoscale_view()
 
         # Run additional parameters as pyplot functions
         # xlim or ylim will overwrite the previous set_lims behavior
@@ -808,6 +759,10 @@ class Affine(BaseAffine):
                              ax=ax,
                              color=color,
                              alpha=alpha)
+
+        ax.relim()
+        ax.autoscale_view()
+
         return ax
 
     def surplus(self, p, q=None):
@@ -1039,6 +994,9 @@ class PPF(BaseAffine):
                             plt_function(*value)
                         else:
                             plt_function(value)
+
+            ax.relim()
+            ax.autoscale_view()
 
             return ax
 

--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -274,6 +274,10 @@ class Equilibrium:
 
         if surplus:
             self.plot_surplus(ax)
+
+        ax.relim()
+        ax.autoscale_view()
+
         return ax
 
     def plot_surplus(self, ax):
@@ -312,6 +316,11 @@ class Equilibrium:
 
         # 4) DWL shading
         self._plot_dwl(ax)
+
+        ax.relim()
+        ax.autoscale_view()
+
+        return ax
 
     def _plot_gov_revenue(self, ax):
         """


### PR DESCRIPTION
## Summary
- use `ax.relim()` and `ax.autoscale_view()` to set the plotting window
- drop heuristic limit calculations

## Testing
- `pytest -q`