### PR TITLE
Update BaseQuadratic domain handling

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -31,6 +31,11 @@ class BaseQuadratic:
         elements : list of :class:`QuadraticElement`, optional
             Preconstructed elements defining the curve. When supplied the
             coefficient arguments are ignored.
+
+        Notes
+        -----
+        Elements that do not define a domain are treated as active for all
+        quantities.
         """
         if elements is None:
             if isinstance(linear_coef, (int, float)):
@@ -130,7 +135,7 @@ class BaseQuadratic:
     def active_element(self, q):
         for piece in self.elements:
             domain = piece._domain
-            if domain and (np.min(domain) <= q <= np.max(domain)):
+            if domain is None or (np.min(domain) <= q <= np.max(domain)):
                 return piece
         return None
 

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -3,6 +3,7 @@ import numpy as np
 from freeride.curves import (
     Affine,
     BaseAffine,
+    BaseQuadratic,
     Demand,
     Supply,
     PPF,
@@ -232,4 +233,13 @@ class TestPPF(unittest.TestCase):
         p1 = PPF(10, -1)
         p2 = PPF(5, -0.5)
         self.assertAlmostEqual((p1 + p2)(7), (p2 + p1)(7))
+
+
+class TestBaseQuadraticRegression(unittest.TestCase):
+
+    def test_numeric_coefficients(self):
+        curve = BaseQuadratic(intercept=1, linear_coef=2, quadratic_coef=3)
+        for q in [-1, 0, 1, 2]:
+            expected = 1 + 2 * q + 3 * q**2
+            self.assertAlmostEqual(curve(q), expected)
 


### PR DESCRIPTION
## Summary
- treat QuadraticElement without `_domain` as active for all quantities
- document default behaviour in `BaseQuadratic.__init__`
- add regression test for domainless BaseQuadratic construction

## Testing
- `pytest -q`