### PR TITLE
Centralize axis autoscaling

### DIFF
--- a/freeride/base.py
+++ b/freeride/base.py
@@ -5,7 +5,7 @@ import numpy as np
 from IPython.display import Latex, display
 
 from freeride.formula import _formula, _quadratic_formula
-from freeride.plotting import AREA_FILLS, textbook_axes
+from freeride.plotting import AREA_FILLS, textbook_axes, finalize_axes
 
 
 class PolyBase(np.polynomial.Polynomial):
@@ -188,8 +188,7 @@ class PolyBase(np.polynomial.Polynomial):
         if textbook_style:
             textbook_axes(ax)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
     # Similar to numpy ABCPolyBase
     def _repr_latex_(self):
@@ -600,8 +599,7 @@ class AffineElement(PolyBase):
             ax.set_ylabel("Price")
             ax.set_xlabel("Quantity")
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -635,8 +633,7 @@ class AffineElement(PolyBase):
 
         ax.fill_between(q, p01, p, zorder=zorder, color=color, alpha=alpha)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -720,8 +717,7 @@ class QuadraticElement(PolyBase):
             # ax.set_ylabel("Price")
             ax.set_xlabel("Quantity")
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -736,8 +732,7 @@ class QuadraticElement(PolyBase):
         ys = self(xs)
         ax.fill_between(xs, 0, ys, zorder=zorder, color=color, alpha=alpha)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -752,8 +747,7 @@ class QuadraticElement(PolyBase):
         ys = self(xs)
         ax.fill_between(xs, ys, y, zorder=zorder, color=color, alpha=alpha)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -842,8 +836,7 @@ class BaseQuadratic:
                 elmt.plot(ax=ax, label=label, max_q=max_q, **plot_dict)
 
         if set_lims:
-            ax.relim()
-            ax.autoscale_view()
+            finalize_axes(ax)
 
         return ax
 

--- a/freeride/costs.py
+++ b/freeride/costs.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numbers
 
 from freeride.base import PolyBase
-from freeride.plotting import textbook_axes
+from freeride.plotting import textbook_axes, finalize_axes
 
 
 ############################################################
@@ -340,8 +340,7 @@ class Cost(PolyBase):
         ax.plot([q,q], [0,p], linestyle = 'dashed', color = 'gray')
         ax.plot([q], [p], marker = 'o')
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         ax.legend()
 
@@ -405,8 +404,7 @@ class Cost(PolyBase):
         if 'tr' in items:
             ax.fill_between([0,q], 0, p, facecolor = 'blue', alpha = 0.1, label = 'TR', hatch = '+')
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -512,7 +510,6 @@ class AverageCost:
         ys = self(xs)
         ax.plot(xs, ys, label = label)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax

--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from freeride.plotting import textbook_axes, AREA_FILLS
+from freeride.plotting import textbook_axes, AREA_FILLS, finalize_axes
 from freeride.formula import _formula
 from freeride.base import QuadraticElement, AffineElement, BaseQuadratic
 from IPython.display import Latex, display
@@ -511,8 +511,7 @@ class Affine(BaseAffine):
                 piece.plot(ax=ax, label=label, max_q=max_q, **plot_dict)
 
         if set_lims:
-            ax.relim()
-            ax.autoscale_view()
+            finalize_axes(ax)
 
         # Apply any leftover kwargs that might be e.g. title, xlim, ylim
         for key, value in kwargs.items():
@@ -548,8 +547,7 @@ class Affine(BaseAffine):
                              color=color,
                              alpha=alpha)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -783,8 +781,7 @@ class PPF(BaseAffine):
                         else:
                             plt_function(value)
 
-            ax.relim()
-            ax.autoscale_view()
+            finalize_axes(ax)
 
             return ax
 

--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -25,6 +25,8 @@ Plotting logic:
 import numpy as np
 import matplotlib.pyplot as plt
 
+from freeride.plotting import finalize_axes
+
 from freeride.curves import Demand, Supply, intersection
 
 
@@ -275,8 +277,7 @@ class Equilibrium:
         if surplus:
             self.plot_surplus(ax)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 
@@ -317,8 +318,7 @@ class Equilibrium:
         # 4) DWL shading
         self._plot_dwl(ax)
 
-        ax.relim()
-        ax.autoscale_view()
+        finalize_axes(ax)
 
         return ax
 

--- a/freeride/plotting.py
+++ b/freeride/plotting.py
@@ -49,3 +49,43 @@ def textbook_axes(ax: Optional[plt.Axes] = None) -> plt.Axes:
     ax.spines["right"].set_visible(False)
 
     return ax
+
+
+def finalize_axes(ax: Optional[plt.Axes] = None) -> plt.Axes:
+    """Autoscale and ensure the origin is visible.
+
+    This convenience wraps ``relim`` and ``autoscale_view`` and then
+    adjusts the limits so that ``(0, 0)`` always falls within the view.
+
+    Parameters
+    ----------
+    ax : matplotlib.axes.Axes, optional
+        Axis to update. If omitted, the current axes are used.
+
+    Returns
+    -------
+    matplotlib.axes.Axes
+        The updated axes instance.
+    """
+    if ax is None:
+        ax = plt.gca()
+
+    ax.relim()
+    ax.autoscale_view()
+
+    xmin, xmax = ax.get_xlim()
+    ymin, ymax = ax.get_ylim()
+
+    if xmin > 0:
+        xmin = 0
+    if xmax < 0:
+        xmax = 0
+    if ymin > 0:
+        ymin = 0
+    if ymax < 0:
+        ymax = 0
+
+    ax.set_xlim(xmin, xmax)
+    ax.set_ylim(ymin, ymax)
+
+    return ax

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 import numpy as np
 
-from freeride.plotting import ALPHA, AREA_FILLS, textbook_axes
+from freeride.plotting import ALPHA, AREA_FILLS, textbook_axes, finalize_axes
 
 
 class TestPlotting(unittest.TestCase):
@@ -47,6 +47,26 @@ class TestPlotting(unittest.TestCase):
         fig, ax = plt.subplots()
         plt.sca(ax)
         result = textbook_axes()
+
+        self.assertIs(result, ax)
+
+    def test_finalize_axes_includes_origin(self):
+        """``finalize_axes`` should ensure the origin is visible."""
+
+        fig, ax = plt.subplots()
+        ax.plot([1, 2], [1, 2])
+        finalize_axes(ax)
+
+        self.assertLessEqual(ax.get_xlim()[0], 0)
+        self.assertLessEqual(ax.get_ylim()[0], 0)
+
+    def test_finalize_axes_uses_current_axes(self):
+        """When no axis is supplied, ``finalize_axes`` should use the current one."""
+
+        fig, ax = plt.subplots()
+        plt.sca(ax)
+        ax.plot([1, 2], [1, 2])
+        result = finalize_axes()
 
         self.assertIs(result, ax)
 


### PR DESCRIPTION
## Summary
- add `finalize_axes` utility to centralize axis autoscaling
- use `finalize_axes` across plotting routines
- test origin inclusion and default axis selection

## Testing
- `pytest -q`