### PR TITLE
Add Revenue subclass and update demand revenue handling

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -4,6 +4,7 @@ from freeride.plotting import textbook_axes, AREA_FILLS, update_axes_limits
 from freeride.formula import _formula
 from freeride.affine import AffineElement
 from freeride.quadratic import QuadraticElement, BaseQuadratic
+from freeride.revenue import Revenue
 from IPython.display import Latex, display
 from bokeh.plotting import figure, show
 from bokeh.models import HoverTool, ColumnDataSource
@@ -602,15 +603,7 @@ class Demand(Affine):
 
     def total_revenue(self):
         
-        elements = list()
-        pieces = [p for p in self.pieces if p]
-        for piece in pieces:
-            coef = 0, piece.intercept, piece.slope
-            revenue_element = QuadraticElement(*coef)
-            revenue_element._domain = sorted(piece._domain)
-            elements.append(revenue_element)
-            
-        return BaseQuadratic(elements=elements)
+        return Revenue.from_demand(self)
 
 
 class Supply(Affine):

--- a/freeride/revenue.py
+++ b/freeride/revenue.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Revenue curve utilities."""
+
+from .quadratic import QuadraticElement, BaseQuadratic
+
+
+class Revenue(BaseQuadratic):
+    """Piecewise quadratic revenue curve.
+
+    This class represents total revenue as a function of quantity. It is
+    typically generated from a :class:`~freeride.curves.Demand` curve and
+    inherits all functionality of :class:`~freeride.quadratic.BaseQuadratic`.
+    """
+
+    @classmethod
+    def from_demand(cls, demand) -> "Revenue":
+        """Construct a Revenue curve from a :class:`Demand` instance."""
+        elements = []
+        pieces = [p for p in demand.pieces if p]
+        for piece in pieces:
+            coef = 0, piece.intercept, piece.slope
+            revenue_element = QuadraticElement(*coef)
+            revenue_element._domain = sorted(piece._domain)
+            elements.append(revenue_element)
+        return cls(elements=elements)
+

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -140,6 +140,8 @@ class TestSurplusAndRevenue(unittest.TestCase):
 
     def test_total_revenue(self):
         revenue_curve = self.demand.total_revenue()
+        from freeride.revenue import Revenue
+        self.assertIsInstance(revenue_curve, Revenue)
         self.assertAlmostEqual(revenue_curve(4), 16.0)
 
 


### PR DESCRIPTION
## Summary
- implement `Revenue` class for total revenue curves derived from `BaseQuadratic`
- have `Demand.total_revenue` build a `Revenue` object using new helper
- import `Revenue` where needed and test for its type

## Testing
- `python -m pytest -q`