### PR TITLE
Add double auction tutorial

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,6 +122,7 @@ received by producers, and the shaded tax revenue rectangle.
 
    tutorials/market_equilibrium
    tutorials/prisoners_dilemma
+   tutorials/double_auction
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,9 +120,9 @@ received by producers, and the shaded tax revenue rectangle.
    :maxdepth: 1
    :caption: Tutorials
 
+   tutorials/double_auction
    tutorials/market_equilibrium
    tutorials/prisoners_dilemma
-   tutorials/double_auction
 
 
 

--- a/docs/notebooks/double_auction.ipynb
+++ b/docs/notebooks/double_auction.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Double Auction\n",
+    "\n",
+    "This notebook demonstrates how to clear a simple double auction using FreeRide."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "!pip install freeride"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from freeride.double_auction import UnitDemand, UnitSupply, DoubleAuction\n\nbuyers = [UnitDemand(10), UnitDemand(9)]\nsellers = [UnitSupply(6), UnitSupply(4)]\n\nauction = DoubleAuction(*buyers, *sellers)\nprint(auction)\nauction.plot()"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials/double_auction.rst
+++ b/docs/tutorials/double_auction.rst
@@ -12,11 +12,6 @@ Double Auction
      </a>
    </div>
 
-FreeRide provides a lightweight way to simulate a sealed bid double auction.  
-Buyers and sellers each submit valuations for at most one unit.  The auction 
-clears by matching the highest buyer valuations with the lowest seller 
-valuations.
-
 UnitDemand and UnitSupply
 -------------------------
 
@@ -31,7 +26,7 @@ Example
 -------
 
 The snippet below creates two buyers and two sellers, clears the auction and 
-plots the resulting allocation.
+plots the demand and supply curves.
 
 .. code-block:: python
 
@@ -47,11 +42,3 @@ plots the resulting allocation.
 
 The output displays the clearing price range and quantity traded, while the plot
 shows the demand and supply schedules as step functions.
-
-Try It Yourself
----------------
-
-Use the **"Open in Colab"** badge above to experiment with your own buyers and 
-sellers.  Adjust their valuations to see how the clearing price range and traded
-quantity respond.
-

--- a/docs/tutorials/double_auction.rst
+++ b/docs/tutorials/double_auction.rst
@@ -1,0 +1,57 @@
+Double Auction
+==============
+
+.. raw:: html
+
+   <div style="margin-bottom: 1rem;">
+     <a href="https://colab.research.google.com/github/alexanderthclark/FreeRide/blob/main/docs/notebooks/double_auction.ipynb" target="_blank">
+       <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab" style="margin-right: 10px;"/>
+     </a>
+     <a href="../notebooks/double_auction.ipynb" download>
+       <img src="https://img.shields.io/badge/Download-Notebook-blue?style=flat&logo=jupyter" alt="Download Notebook"/>
+     </a>
+   </div>
+
+FreeRide provides a lightweight way to simulate a sealed bid double auction.  
+Buyers and sellers each submit valuations for at most one unit.  The auction 
+clears by matching the highest buyer valuations with the lowest seller 
+valuations.
+
+UnitDemand and UnitSupply
+-------------------------
+
+:class:`~freeride.double_auction.UnitDemand` represents a buyer.  Pass the 
+agent's willingness to pay for each unit as positional arguments.  Likewise 
+:class:`~freeride.double_auction.UnitSupply` represents a seller and takes the 
+willingness to accept for each unit.  Both classes store the list of valuations 
+and expose ``valuation`` for the first unit and ``endowment`` for the number of 
+units held.
+
+Example
+-------
+
+The snippet below creates two buyers and two sellers, clears the auction and 
+plots the resulting allocation.
+
+.. code-block:: python
+
+   from freeride.double_auction import UnitDemand, UnitSupply, DoubleAuction
+
+   buyers = [UnitDemand(10), UnitDemand(9)]
+   sellers = [UnitSupply(6), UnitSupply(4)]
+
+   auction = DoubleAuction(*buyers, *sellers)
+   print(auction)
+
+   ax = auction.plot()
+
+The output displays the clearing price range and quantity traded, while the plot
+shows the demand and supply schedules as step functions.
+
+Try It Yourself
+---------------
+
+Use the **"Open in Colab"** badge above to experiment with your own buyers and 
+sellers.  Adjust their valuations to see how the clearing price range and traded
+quantity respond.
+


### PR DESCRIPTION
## Summary
- document `freeride.double_auction` in a new tutorial
- provide example buyers and sellers in the tutorial
- add matching Jupyter notebook
- link the tutorial from the docs index

## Testing
- `pytest -q`