### PR TITLE
Remove trailing whitespace

### DIFF
--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -315,7 +315,7 @@ class Demand(Affine):
         """
         super().__init__(intercept, slope, elements, inverse)
         self._check_slope()
-        
+
         # Warn about perfectly elastic segments
         if self.has_perfectly_elastic_segment:
             warnings.warn(
@@ -330,7 +330,7 @@ class Demand(Affine):
         for slope in self.slope:
             if slope > 0:
                 raise Exception("Upward-sloping demand curve.")
-        
+
         # Check for economically reasonable demand curves
         for intercept in self.intercept:
             if intercept <= 0:
@@ -339,18 +339,18 @@ class Demand(Affine):
                     f"A demand curve represents willingness to pay, so the price intercept "
                     f"should be positive."
                 )
-        
+
         if not self.has_perfectly_elastic_segment:
             if self.q(0) < 0:
                 raise Exception("Negative demand.")
-    
+
     def q(self, p):
         """
         Calculate quantity demanded at price p, handling perfectly elastic segments.
-        
+
         For horizontal demand at price P*:
         - q(P*) = 0 (with warning about indeterminacy)
-        - q(P > P*) = 0 
+        - q(P > P*) = 0
         - q(P < P*) = ∞
         """
         # Check if we have perfectly elastic segments
@@ -369,7 +369,7 @@ class Demand(Affine):
                         return 0
                     else:  # p < p_star
                         return np.inf
-        
+
         # Default behavior for non-horizontal curves
         return super().q(p)
 
@@ -377,13 +377,13 @@ class Demand(Affine):
         return self.surplus(p, q)
 
     def total_revenue(self):
-        
+
         return Revenue.from_demand(self)
 
     def marginal_revenue(self):
-        
+
         return MarginalRevenue.from_demand(self)
-    
+
     def __and__(self, other):
         """Create a Market from intersection with Supply using & operator."""
         from .equilibrium import Market
@@ -401,7 +401,7 @@ class Supply(Affine):
         """
         super().__init__(intercept, slope, elements, inverse)
         self._check_slope()
-        
+
         # Warn about perfectly elastic segments
         if self.has_perfectly_elastic_segment:
             warnings.warn(
@@ -419,14 +419,14 @@ class Supply(Affine):
         if not self.has_perfectly_elastic_segment:
             if self.q(0) < 0:
                 raise Exception("Negative supply.")
-    
+
     def q(self, p):
         """
         Calculate quantity supplied at price p, handling perfectly elastic segments.
-        
+
         For horizontal supply at price P*:
         - q(P*) = 0 (with warning about indeterminacy)
-        - q(P > P*) = ∞ 
+        - q(P > P*) = ∞
         - q(P < P*) = 0
         """
         # Check if we have perfectly elastic segments
@@ -445,13 +445,13 @@ class Supply(Affine):
                         return np.inf
                     else:  # p < p_star
                         return 0
-        
+
         # Default behavior for non-horizontal curves
         return super().q(p)
 
     def producer_surplus(self, p, q = None):
         return -self.surplus(p, q)
-    
+
     def __and__(self, other):
         """Create a Market from intersection with Demand using & operator."""
         from .equilibrium import Market

--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -68,7 +68,7 @@ class Equilibrium:
                 "due to implementation limitations (not economic theory). "
                 "These curves have indeterminate quantities at the equilibrium price."
             )
-        
+
         self.demand = demand
         self.supply = supply
 

--- a/freeride/games.py
+++ b/freeride/games.py
@@ -148,13 +148,13 @@ class Game:
 
     def nash_equilibria(self) -> List[Tuple[str, str]]:
         """Compute pure strategy Nash equilibria.
-        
+
         Returns
         -------
         list of tuple of str
             List of Nash equilibria as strategy profiles (action name pairs).
             Each equilibrium is a tuple of (player1_action, player2_action).
-            A Nash equilibrium is a strategy profile where no player can 
+            A Nash equilibrium is a strategy profile where no player can
             unilaterally deviate and improve their payoff.
         """
         br1, br2 = self.best_responses()

--- a/freeride/monopoly.py
+++ b/freeride/monopoly.py
@@ -26,7 +26,7 @@ class Monopoly:
 
     def _solve(self):
         candidates = []
-        
+
         # Find interior solutions where MR = MC
         # For each MR piece, solve MR(q) = MC(q)
         for mr_piece in [p for p in self._mr.pieces if p]:
@@ -55,14 +55,14 @@ class Monopoly:
             if piece and piece._domain:
                 # Right boundary of [a,b) is where discontinuities can occur
                 boundary_points.add(max(piece._domain))
-        
+
         for q_boundary in boundary_points:
             if q_boundary <= 0:
                 continue
-                
+
             # Calculate MC at the boundary
             mc_val = self._mc(q_boundary)
-            
+
             # Find MR left limit (from piece ending at this boundary)
             mr_left = None
             for piece in self._mr.pieces:
@@ -70,15 +70,15 @@ class Monopoly:
                     # This piece ends at the boundary - get left limit
                     mr_left = piece(q_boundary)
                     break
-            
-            # Find MR right limit (from piece starting at this boundary) 
+
+            # Find MR right limit (from piece starting at this boundary)
             mr_right = None
             for piece in self._mr.pieces:
                 if piece and piece._domain and min(piece._domain) == q_boundary:
                     # This piece starts at the boundary - get right limit
                     mr_right = piece(q_boundary)
                     break
-            
+
             # If MC passes through the MR gap, this is profit-maximizing
             if mr_left is not None and mr_right is not None and mr_left != mr_right:
                 # Check if MC is between the left and right limits

--- a/run_notebooks.py
+++ b/run_notebooks.py
@@ -9,7 +9,7 @@ def execute_notebooks(notebooks_directory):
     for filename in os.listdir(notebooks_directory):
         if filename.endswith("-out.ipynb"):
             os.remove(os.path.join(notebooks_directory, filename))
-    
+
     # Execute notebooks and save with -out.ipynb suffix
     for filename in os.listdir(notebooks_directory):
         if filename.endswith(".ipynb") and not filename.endswith("-out.ipynb"):

--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -46,7 +46,7 @@ class TestDoubleAuction(unittest.TestCase):
         self.assertEqual(auction.q, 3)
         self.assertEqual(price0, 3)
         self.assertEqual(price1, 4)
-        
+
     def tearDown(self):
         pass
 

--- a/tests/test_domain_conventions.py
+++ b/tests/test_domain_conventions.py
@@ -8,21 +8,21 @@ from freeride.affine import AffineElement
 
 
 class TestDomainConventions(unittest.TestCase):
-    
+
     def test_single_piece_closed_interval(self):
         """Single-piece functions should use [a,b] (closed interval)."""
         demand = Demand(10, -1)  # P = 10 - Q
-        
+
         self.assertAlmostEqual(demand.p(0), 10.0)
         self.assertAlmostEqual(demand.p(10), 0.0)
         self.assertFalse(np.isnan(demand.p(10)))
-    
+
     def test_piecewise_boundary_evaluation(self):
         """Test evaluation at segment boundaries."""
         d1 = Demand(20, -1)    # P = 20 - Q
         d2 = Demand(15, -0.5)  # P = 15 - 0.5Q
         piecewise = d1 + d2
-        
+
         # Test continuity across the domain
         q_values = [0, 5, 10, 20, 30, 40, 50]
         for i in range(len(q_values) - 1):
@@ -30,42 +30,42 @@ class TestDomainConventions(unittest.TestCase):
             p1, p2 = piecewise.p(q1), piecewise.p(q2)
             # Prices should decrease as quantity increases
             self.assertGreaterEqual(p1, p2)
-    
+
     def test_piecewise_full_domain(self):
         """Test that piecewise functions work across full domain."""
         d1 = Demand(20, -1)    # q-intercept at 20
         d2 = Demand(15, -0.5)  # q-intercept at 30
         piecewise = d1 + d2
-        
+
         # Total q-intercept is 50
         test_points = [0, 5, 10, 20, 30, 40, 49.9, 50]
-        
+
         for q in test_points:
             p = piecewise.p(q)
             self.assertFalse(np.isnan(p), f"Got NaN at q={q}")
-        
+
         # Right endpoint should work
         self.assertAlmostEqual(piecewise.p(50), 0.0)
-    
+
     def test_active_piece_selection(self):
         """Test that correct piece is selected at boundaries."""
         d1 = Demand(20, -1)
         d2 = Demand(15, -0.5)
         piecewise = d1 + d2
-        
+
         # Test that we get valid pieces at various points
         test_qs = [0, 1, 5, 10, 25, 45, 49]
         for q in test_qs:
             active = piecewise._get_active_piece(q)
             self.assertIsNotNone(active, f"No active piece at q={q}")
-    
+
     def test_marginal_revenue_boundaries(self):
         """Test MarginalRevenue at piece boundaries."""
         d1 = Demand(20, -1)
         d2 = Demand(10, -0.5)
         kinked = d1 + d2
         mr = MarginalRevenue.from_demand(kinked)
-        
+
         # MR should be defined across the domain
         test_qs = [0, 5, 10, 15, 20]
         for q in test_qs:
@@ -73,12 +73,12 @@ class TestDomainConventions(unittest.TestCase):
             # Should get a value (not NaN) within reasonable domain
             if q <= 20:
                 self.assertFalse(np.isnan(mr_val), f"MR is NaN at q={q}")
-    
+
     def test_affine_element_domain(self):
         """Test base AffineElement domain handling."""
         elem = AffineElement(10, -1)
         elem._domain = [0, 10]
-        
+
         self.assertTrue(elem.in_domain(0))
         self.assertTrue(elem.in_domain(10))
         self.assertFalse(elem.in_domain(11))

--- a/tests/test_horizontal_curves.py
+++ b/tests/test_horizontal_curves.py
@@ -8,7 +8,7 @@ from freeride.equilibrium import Equilibrium
 
 class TestHorizontalCurves(unittest.TestCase):
     """Test cases for horizontal (perfectly elastic) curves."""
-    
+
     def test_horizontal_supply_creation_warns(self):
         """Test that creating horizontal supply triggers a warning."""
         with warnings.catch_warnings(record=True) as w:
@@ -16,15 +16,15 @@ class TestHorizontalCurves(unittest.TestCase):
             # Filter out numpy warnings
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             warnings.filterwarnings("ignore", message="The truth value")
-            
+
             s = Supply(5, 0)
-            
+
             # Should have at least one warning about perfectly elastic curve
-            elastic_warnings = [warning for warning in w 
+            elastic_warnings = [warning for warning in w
                               if warning.category == UserWarning and
                               "perfectly elastic supply" in str(warning.message)]
             self.assertGreater(len(elastic_warnings), 0)
-    
+
     def test_horizontal_demand_creation_warns(self):
         """Test that creating horizontal demand triggers a warning."""
         with warnings.catch_warnings(record=True) as w:
@@ -32,68 +32,68 @@ class TestHorizontalCurves(unittest.TestCase):
             # Filter out numpy warnings
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             warnings.filterwarnings("ignore", message="The truth value")
-            
+
             d = Demand(10, 0)
-            
+
             # Should have at least one warning about perfectly elastic curve
-            elastic_warnings = [warning for warning in w 
+            elastic_warnings = [warning for warning in w
                               if warning.category == UserWarning and
                               "perfectly elastic demand" in str(warning.message)]
             self.assertGreater(len(elastic_warnings), 0)
-    
+
     def test_horizontal_supply_q_method(self):
         """Test the q method for horizontal supply curves."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             s = Supply(5, 0)  # Horizontal at P=5
-            
+
             # At P=5, should return inf (with warning in real use)
             self.assertTrue(np.isinf(s.q(5)))
-            
+
             # Above P=5, should return inf
             self.assertTrue(np.isinf(s.q(6)))
-            
+
             # Below P=5, should return 0
             self.assertEqual(s.q(4), 0)
-    
+
     def test_horizontal_demand_q_method(self):
         """Test the q method for horizontal demand curves."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             d = Demand(10, 0)  # Horizontal at P=10
-            
+
             # At P=10, should return inf (with warning in real use)
             self.assertTrue(np.isinf(d.q(10)))
-            
+
             # Above P=10, should return 0
             self.assertEqual(d.q(11), 0)
-            
+
             # Below P=10, should return inf
             self.assertTrue(np.isinf(d.q(9)))
-    
+
     def test_equilibrium_blocks_horizontal_supply(self):
         """Test that Equilibrium blocks horizontal supply curves."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             s = Supply(5, 0)  # Horizontal supply
             d = Demand(10, -1)  # Normal demand
-            
+
             with self.assertRaises(ValueError) as cm:
                 eq = Equilibrium(d, s)
-            
+
             self.assertIn("perfectly elastic", str(cm.exception))
             self.assertIn("supply", str(cm.exception).lower())
-    
+
     def test_equilibrium_blocks_horizontal_demand(self):
         """Test that Equilibrium blocks horizontal demand curves."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             d = Demand(8, 0)  # Horizontal demand
             s = Supply(2, 1)  # Normal supply
-            
+
             with self.assertRaises(ValueError) as cm:
                 eq = Equilibrium(d, s)
-            
+
             self.assertIn("perfectly elastic", str(cm.exception))
             self.assertIn("demand", str(cm.exception).lower())
 

--- a/tests/test_intersection_operator.py
+++ b/tests/test_intersection_operator.py
@@ -4,57 +4,57 @@ from freeride import Demand, Supply, Market
 
 class TestIntersectionOperator(unittest.TestCase):
     """Test the & operator for creating Market objects from Demand and Supply."""
-    
+
     def setUp(self):
         """Set up test curves."""
         self.demand = Demand(10, -1)
         self.supply = Supply(2, 1)
-    
+
     def test_demand_and_supply(self):
         """Test Demand & Supply creates correct Market."""
         market = self.demand & self.supply
         self.assertIsInstance(market, Market)
         self.assertEqual(market.p, 6.0)
         self.assertEqual(market.q, 4.0)
-    
+
     def test_supply_and_demand(self):
         """Test Supply & Demand creates correct Market."""
         market = self.supply & self.demand
         self.assertIsInstance(market, Market)
         self.assertEqual(market.p, 6.0)
         self.assertEqual(market.q, 4.0)
-    
+
     def test_order_independence(self):
         """Test that order doesn't matter: d & s == s & d."""
         market1 = self.demand & self.supply
         market2 = self.supply & self.demand
-        
+
         self.assertEqual(market1.p, market2.p)
         self.assertEqual(market1.q, market2.q)
         self.assertEqual(market1.consumer_surplus, market2.consumer_surplus)
         self.assertEqual(market1.producer_surplus, market2.producer_surplus)
-    
+
     def test_equivalence_to_constructor(self):
         """Test that & operator gives same result as Market constructor."""
         market_intersection = self.demand & self.supply
         market_constructor = Market(self.demand, self.supply)
-        
+
         self.assertEqual(market_intersection.p, market_constructor.p)
         self.assertEqual(market_intersection.q, market_constructor.q)
-    
+
     def test_invalid_intersection(self):
         """Test that & operator with non-curve objects raises TypeError."""
         with self.assertRaises(TypeError):
             self.demand & "not a supply curve"
-        
+
         with self.assertRaises(TypeError):
             self.supply & 42
-    
+
     def test_with_formula_curves(self):
         """Test & operator with curves created from formulas."""
         d = Demand.from_formula("P = 20 - 2*Q")
         s = Supply.from_formula("P = 5 + Q")
-        
+
         market = d & s
         self.assertIsInstance(market, Market)
         self.assertAlmostEqual(market.p, 10.0, places=2)

--- a/tests/test_monopoly.py
+++ b/tests/test_monopoly.py
@@ -29,11 +29,11 @@ class TestMonopoly(unittest.TestCase):
         d1 = Demand(20, -1)    # P = 20 - Q, steep segment
         d2 = Demand(10, -0.5)  # P = 10 - 0.5*Q, flat segment
         kinked_demand = d1 + d2
-        
+
         # Use constant marginal cost
         cost = Cost(0, 3)  # MC = 3
         m = Monopoly(kinked_demand, cost)
-        
+
         # Verify this is truly profit-maximizing by checking grid
         q_grid = np.linspace(0.1, 25, 1000)
         profits = []
@@ -44,9 +44,9 @@ class TestMonopoly(unittest.TestCase):
                 profits.append(profit)
             else:
                 profits.append(-np.inf)
-        
+
         max_profit_grid = max(profits)
-        
+
         # Our solution should be within 1% of the grid maximum
         self.assertGreater(m.profit, 0.99 * max_profit_grid)
 
@@ -54,13 +54,13 @@ class TestMonopoly(unittest.TestCase):
         """Test kinked demand with quadratic cost function."""
         # Create kinked demand
         d1 = Demand(15, -0.8)   # P = 15 - 0.8*Q
-        d2 = Demand(8, -0.3)    # P = 8 - 0.3*Q  
+        d2 = Demand(8, -0.3)    # P = 8 - 0.3*Q
         kinked_demand = d1 + d2
-        
+
         # Quadratic cost: TC = 2 + Q + 0.1*Q^2, so MC = 1 + 0.2*Q
         cost = Cost([2, 1, 0.1])
         m = Monopoly(kinked_demand, cost)
-        
+
         # Verify this is profit-maximizing using grid search
         q_grid = np.linspace(0.1, 30, 2000)
         profits = []
@@ -71,11 +71,11 @@ class TestMonopoly(unittest.TestCase):
                 profits.append(profit)
             else:
                 profits.append(-np.inf)
-                
+
         max_profit_grid = max(profits)
         best_q_idx = np.argmax(profits)
         best_q_grid = q_grid[best_q_idx]
-        
+
         # Our solution should be very close to grid optimum
         self.assertGreater(m.profit, 0.99 * max_profit_grid)
         self.assertAlmostEqual(m.q, best_q_grid, delta=0.1)
@@ -83,25 +83,25 @@ class TestMonopoly(unittest.TestCase):
     def test_kinked_demand_single_segment_only(self):
         """Test kinked demand where monopolist serves only one segment."""
         # Use your exact suggestion: P = 10 - Q and P = 1 - 10*Q
-        d1 = Demand(10, -1)     # P = 10 - Q  
+        d1 = Demand(10, -1)     # P = 10 - Q
         d2 = Demand(1, -10)     # P = 1 - 10*Q (very steep, low willingness to pay)
         kinked_demand = d1 + d2
-        
+
         # With MC = 0, monopolist will choose Q where MR = 0 on the profitable segment
-        cost = Cost(0, 0)  
+        cost = Cost(0, 0)
         m = Monopoly(kinked_demand, cost)
-        
+
         # For first segment P = 10 - Q, MR = 10 - 2Q
         # Setting MR = 0: Q = 5, P = 5
         # At Q = 5, first segment gives profit = 5 * 5 = 25
         # Second segment at any reasonable Q gives much lower prices/profits
         # So monopolist should choose Q = 5, P = 5 (still pricing above second segment)
-        
-        self.assertAlmostEqual(m.q, 5.0, places=1)  
-        self.assertAlmostEqual(m.p, 5.0, places=1)  
+
+        self.assertAlmostEqual(m.q, 5.0, places=1)
+        self.assertAlmostEqual(m.p, 5.0, places=1)
         # Verify this price is indeed above what second segment would offer
         self.assertGreater(m.p, 1.0)  # Much higher than second segment's max price
-        
+
         # Verify optimality with grid search
         q_grid = np.linspace(0.1, 15, 1000)
         profits = []
@@ -112,7 +112,7 @@ class TestMonopoly(unittest.TestCase):
                 profits.append(profit)
             else:
                 profits.append(-np.inf)
-        
+
         max_profit_grid = max(profits)
         self.assertGreater(m.profit, 0.99 * max_profit_grid)
 
@@ -122,22 +122,22 @@ class TestMonopoly(unittest.TestCase):
         d1 = Demand(15, -0.5)   # P = 15 - 0.5*Q, gentle slope, high willingness to pay
         d2 = Demand(12, -1)     # P = 12 - Q, steeper but still reasonable
         kinked_demand = d1 + d2
-        
+
         # Use marginal cost that makes serving both segments optimal
         cost = Cost(0, 2)  # MC = 2
         m = Monopoly(kinked_demand, cost)
-        
+
         # Find the kink point (where the segments meet)
         # d1: P = 15 - 0.5*Q, d2: P = 12 - Q
         # They intersect when 15 - 0.5*Q = 12 - Q
         # 3 = -0.5*Q, so Q = 6, P = 12
         kink_q = 6.0
         kink_p = 12.0
-        
+
         # Monopolist should operate beyond the kink (serve both segments)
         self.assertGreater(m.q, kink_q)  # Should serve both segments
         self.assertLess(m.p, kink_p)     # Price should be below kink point
-        
+
         # Verify optimality with grid search
         q_grid = np.linspace(0.1, 20, 1500)
         profits = []
@@ -148,11 +148,11 @@ class TestMonopoly(unittest.TestCase):
                 profits.append(profit)
             else:
                 profits.append(-np.inf)
-        
+
         max_profit_grid = max(profits)
         best_q_idx = np.argmax(profits)
         best_q_grid = q_grid[best_q_idx]
-        
+
         # Verify we found the optimum
         self.assertGreater(m.profit, 0.99 * max_profit_grid)
         self.assertAlmostEqual(m.q, best_q_grid, delta=0.1)

--- a/tests/test_revenue.py
+++ b/tests/test_revenue.py
@@ -5,83 +5,83 @@ from freeride.revenue import Revenue, MarginalRevenue
 
 
 class TestRevenue(unittest.TestCase):
-    
+
     def setUp(self):
         # Create a simple linear demand: P = 10 - Q
         self.demand = Demand.from_formula("P = 10 - Q")
         self.revenue = Revenue.from_demand(self.demand)
-        
+
         # Create a piecewise demand for more complex tests (future enhancement)
         # self.piecewise_demand = ... # Would need custom construction
-        
+
     def test_revenue_from_simple_demand(self):
         """Test revenue calculation from simple linear demand P = 10 - Q."""
         # For P = 10 - Q, Revenue R = P*Q = (10 - Q)*Q = 10Q - Q^2
         # So at Q = 2: R = 10*2 - 2^2 = 20 - 4 = 16
         self.assertAlmostEqual(self.revenue(2), 16, places=5)
-        
+
         # At Q = 5: R = 10*5 - 5^2 = 50 - 25 = 25
         self.assertAlmostEqual(self.revenue(5), 25, places=5)
-        
+
         # At Q = 0: R = 0
         self.assertAlmostEqual(self.revenue(0), 0, places=5)
-        
+
     def test_revenue_maximum(self):
         """Test that revenue is maximized where MR = 0."""
         # For P = 10 - Q, MR = 10 - 2Q
         # MR = 0 when Q = 5, and max revenue = 25
         q_max = 5
         max_revenue = 25
-        
+
         # Check that revenue at Q = 5 is indeed the maximum
         self.assertAlmostEqual(self.revenue(q_max), max_revenue, places=5)
-        
+
         # Check that revenue is lower at nearby points
         self.assertLess(self.revenue(q_max - 0.1), max_revenue)
         self.assertLess(self.revenue(q_max + 0.1), max_revenue)
-        
+
     def test_revenue_properties(self):
         """Test basic properties of revenue curve."""
         # Revenue should be 0 at Q = 0 and Q = 10 (where P = 0)
         self.assertAlmostEqual(self.revenue(0), 0, places=5)
         self.assertAlmostEqual(self.revenue(10), 0, places=5)
-        
+
         # Revenue should be positive between 0 and 10
         for q in [1, 3, 7, 9]:
             self.assertGreater(self.revenue(q), 0)
 
 
 class TestMarginalRevenue(unittest.TestCase):
-    
+
     def setUp(self):
         # Create a simple linear demand: P = 10 - Q
         self.demand = Demand.from_formula("P = 10 - Q")
         self.marginal_revenue = MarginalRevenue.from_demand(self.demand)
-        
+
     def test_marginal_revenue_from_simple_demand(self):
         """Test marginal revenue calculation from simple linear demand P = 10 - Q."""
         # For P = 10 - Q, MR = 10 - 2Q
         # At Q = 2: MR = 10 - 2*2 = 6
         self.assertAlmostEqual(self.marginal_revenue(2), 6, places=5)
-        
+
         # At Q = 0: MR = 10
         self.assertAlmostEqual(self.marginal_revenue(0), 10, places=5)
-        
+
         # At Q = 5: MR = 0
         self.assertAlmostEqual(self.marginal_revenue(5), 0, places=5)
-        
+
     def test_marginal_revenue_properties(self):
         """Test basic properties of marginal revenue curve."""
         # For linear demand, MR should have twice the slope
         # P = 10 - Q has slope -1, so MR = 10 - 2Q has slope -2
-        
+
         # MR should decline as quantity increases
         self.assertGreater(self.marginal_revenue(1), self.marginal_revenue(2))
         self.assertGreater(self.marginal_revenue(2), self.marginal_revenue(3))
-        
+
         # MR should be zero where revenue is maximized
         self.assertAlmostEqual(self.marginal_revenue(5), 0, places=5)
-        
+
     def test_marginal_revenue_intercept(self):
         """Test that MR has same intercept as demand but twice the slope."""
         # For P = 10 - Q, MR should be 10 - 2Q
@@ -91,56 +91,56 @@ class TestMarginalRevenue(unittest.TestCase):
 
 
 class TestRevenueIntegration(unittest.TestCase):
-    
+
     def setUp(self):
         # Test with different demand curves
         self.steep_demand = Demand.from_formula("P = 20 - 4*Q")  # Steep demand
         self.flat_demand = Demand.from_formula("P = 10 - 0.5*Q")  # Flat demand
-        
+
     def test_revenue_from_steep_demand(self):
         """Test revenue calculation with steep demand curve."""
         revenue = Revenue.from_demand(self.steep_demand)
         # P = 20 - 4Q, so R = (20 - 4Q)*Q = 20Q - 4Q^2
         # At Q = 1: R = 20 - 4 = 16
         self.assertAlmostEqual(revenue(1), 16, places=5)
-        
+
     def test_revenue_from_flat_demand(self):
         """Test revenue calculation with flat demand curve."""
         revenue = Revenue.from_demand(self.flat_demand)
         # P = 10 - 0.5Q, so R = (10 - 0.5Q)*Q = 10Q - 0.5Q^2
         # At Q = 2: R = 20 - 2 = 18
         self.assertAlmostEqual(revenue(2), 18, places=5)
-        
+
     def test_marginal_revenue_slopes(self):
         """Test that MR has twice the slope of demand."""
         steep_mr = MarginalRevenue.from_demand(self.steep_demand)
         flat_mr = MarginalRevenue.from_demand(self.flat_demand)
-        
+
         # Steep demand: P = 20 - 4Q, MR = 20 - 8Q
         self.assertAlmostEqual(steep_mr(0), 20, places=5)
         self.assertAlmostEqual(steep_mr(1), 12, places=5)  # 20 - 8*1
-        
+
         # Flat demand: P = 10 - 0.5Q, MR = 10 - Q
         self.assertAlmostEqual(flat_mr(0), 10, places=5)
         self.assertAlmostEqual(flat_mr(2), 8, places=5)   # 10 - 1*2
 
 
 class TestKinkedDemandMarginalRevenue(unittest.TestCase):
-    
+
     def setUp(self):
         """Create a kinked demand curve to test discontinuous MR."""
         d1 = Demand(20, -1)  # P = 20 - Q, steep segment
         d2 = Demand(10, -0.5)  # P = 10 - 0.5*Q, flat segment
         self.kinked_demand = d1 + d2
-        
+
     def test_discontinuous_marginal_revenue(self):
         """Test that MR is discontinuous at the kink."""
         mr = MarginalRevenue.from_demand(self.kinked_demand)
-        
+
         # Test points on either side of Q=10 kink
-        mr_before = mr(9.9)  
+        mr_before = mr(9.9)
         mr_after = mr(10.1)
-        
+
         # Should have a significant jump (discontinuity)
         gap = abs(mr_after - mr_before)
         self.assertGreater(gap, 2, "MR should be discontinuous at the kink")


### PR DESCRIPTION
## Summary
- trim trailing spaces in all Python modules

## Testing
- `python -m unittest discover tests/`

------
https://chatgpt.com/codex/tasks/task_e_6862e9adfc688327b96d125799b6a693