### PR TITLE
Add tests for empty auction scenarios

### DIFF
--- a/freeride/double_auction.py
+++ b/freeride/double_auction.py
@@ -133,6 +133,11 @@ class DoubleAuction:
         supplies = sorted(supplies, key=_sort_key)
         self.supply = supplies
 
+        if not demands:
+            raise IndexError("Auction requires at least one buyer")
+        if not supplies:
+            raise IndexError("Auction requires at least one seller")
+
         price_range, n_trades = self.clear()
         self.price_range = price_range
         self.p = price_range

--- a/tests/test_auction.py
+++ b/tests/test_auction.py
@@ -72,11 +72,15 @@ class TestDoubleAuctionAdditional(unittest.TestCase):
 
     def test_empty_demand_raises(self):
         """An auction with no demand should raise ``IndexError``."""
-        pass
+        sellers = [UnitSupply(5), UnitSupply(4)]
+        with self.assertRaises(IndexError):
+            DoubleAuction(*sellers)
 
     def test_empty_supply_raises(self):
         """An auction with no supply should raise ``IndexError``."""
-        pass
+        buyers = [UnitDemand(8), UnitDemand(7)]
+        with self.assertRaises(IndexError):
+            DoubleAuction(*buyers)
 
     def test_plot_returns_axes(self):
         """The ``plot`` method should return a Matplotlib ``Axes`` object."""


### PR DESCRIPTION
## Summary
- add unit tests covering auctions with no demand or no supply
- raise `IndexError` when creating a `DoubleAuction` without buyers or sellers

## Testing
- `python -m unittest discover tests`

------
https://chatgpt.com/codex/tasks/task_e_6872bf96ce048327bfba2ed7f34f5d30