### PR TITLE
refactor: raise ValueError instead of generic Exception

### DIFF
--- a/freeride/affine.py
+++ b/freeride/affine.py
@@ -113,7 +113,9 @@ class AffineElement(PolyBase):
 
     def __call__(self, x):
         if self.slope == np.inf:
-            raise Exception(f"Undefined (perfectly inelastic at {self.q_intercept})")
+            raise ValueError(
+                f"Undefined (perfectly inelastic at {self.q_intercept})"
+            )
         else:
             return self.intercept + self.slope * x
 
@@ -466,7 +468,7 @@ def blind_sum(*curves):
         qslope = np.sum([1/c.slope for c in curves])
         return AffineElement(qintercept, qslope, inverse = False)
     else:
-        raise Exception("Perfectly Elastic and Inelastic curves not supported")
+        raise ValueError("Perfectly Elastic and Inelastic curves not supported")
 
 
 def horizontal_sum(*curves):

--- a/freeride/base.py
+++ b/freeride/base.py
@@ -92,7 +92,7 @@ class PolyBase(np.polynomial.Polynomial):
         elif len(symbols) == 2:
             x, y = symbols
         else:
-            raise Exception("symbols not properly set")
+            raise ValueError("symbols not properly set")
         self.x, self.y = x, y
         self.symbols = self.x, self.y
         self._symbol = self.x

--- a/freeride/curves.py
+++ b/freeride/curves.py
@@ -248,12 +248,12 @@ class Demand(Affine):
     def _check_slope(self):
         for slope in self.slope:
             if slope > 0:
-                raise Exception("Upward-sloping demand curve.")
+                raise ValueError("Upward-sloping demand curve.")
 
         # Check for economically reasonable demand curves
         for intercept in self.intercept:
             if intercept <= 0:
-                raise Exception(
+                raise ValueError(
                     "Demand curve intercept must be positive "
                     f"(got {intercept}). "
                     "A demand curve represents willingness to pay, so "
@@ -262,7 +262,7 @@ class Demand(Affine):
 
         if not self.has_perfectly_elastic_segment:
             if self.q(0) < 0:
-                raise Exception("Negative demand.")
+                raise ValueError("Negative demand.")
 
     def q(self, p):
         """
@@ -368,10 +368,10 @@ class Supply(Affine):
     def _check_slope(self):
         for slope in self.slope:
             if slope < 0:
-                raise Exception("Downward-sloping supply curve.")
+                raise ValueError("Downward-sloping supply curve.")
         if not self.has_perfectly_elastic_segment:
             if self.q(0) < 0:
-                raise Exception("Negative supply.")
+                raise ValueError("Negative supply.")
 
     def q(self, p):
         """

--- a/freeride/equilibrium.py
+++ b/freeride/equilibrium.py
@@ -102,12 +102,12 @@ class Equilibrium:
         if self.__world_price is not None:
             interventions.append("world_price")
         if len(interventions) > 1:
-            raise Exception(
+            raise ValueError(
                 f"Multiple interventions not supported: {interventions}"
             )
 
         if self.__tariff != 0 and self.__world_price is None:
-            raise Exception(
+            raise ValueError(
                 "A nonzero tariff requires a 'world_price' to be set."
             )
 
@@ -496,7 +496,7 @@ class Equilibrium:
             self.__floor is not None,
             self.__world_price is not None
         ]):
-            raise Exception("Multiple interventions not supported.")
+            raise ValueError("Multiple interventions not supported.")
         self.__tax = val
         self._verify_single_intervention()
         self._compute()
@@ -512,7 +512,7 @@ class Equilibrium:
             self.__floor is not None,
             self.__world_price is not None
         ]):
-            raise Exception("Multiple interventions not supported.")
+            raise ValueError("Multiple interventions not supported.")
         self.__tax = -val
         self._verify_single_intervention()
         self._compute()
@@ -528,7 +528,7 @@ class Equilibrium:
             self.__floor is not None,
             self.__world_price is not None
         ]):
-            raise Exception("Multiple interventions not supported.")
+            raise ValueError("Multiple interventions not supported.")
         self.__ceiling = val
         self._verify_single_intervention()
         self._compute()
@@ -544,7 +544,7 @@ class Equilibrium:
             self.__ceiling is not None,
             self.__world_price is not None
         ]):
-            raise Exception("Multiple interventions not supported.")
+            raise ValueError("Multiple interventions not supported.")
         self.__floor = val
         self._verify_single_intervention()
         self._compute()
@@ -560,7 +560,7 @@ class Equilibrium:
             self.__ceiling is not None,
             self.__floor is not None
         ]):
-            raise Exception("Multiple interventions not supported.")
+            raise ValueError("Multiple interventions not supported.")
         self.__world_price = val
         self._verify_single_intervention()
         self._compute()
@@ -579,9 +579,9 @@ class Equilibrium:
     @tariff.setter
     def tariff(self, val):
         if val != 0 and self.__world_price is None:
-            raise Exception("A nonzero tariff requires a 'world_price'.")
+            raise ValueError("A nonzero tariff requires a 'world_price'.")
         if val < 0:
-            raise Exception(
+            raise ValueError(
                 "Import subsidies (negative tariffs) are not supported."
             )
         self.__tariff = val

--- a/tests/test_curves.py
+++ b/tests/test_curves.py
@@ -149,21 +149,21 @@ class TestCurveEdgeCases(unittest.TestCase):
     """Edge case tests for curve utilities."""
 
     def test_upward_sloping_demand_raises(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             Demand(5, 1)
 
     def test_downward_sloping_supply_raises(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             Supply(0, -1)
 
     def test_blind_sum_rejects_elastic(self):
         elastic = AffineElement(5, 0)  # perfectly elastic
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             blind_sum(elastic)
 
     def test_horizontal_sum_rejects_inelastic(self):
         inelastic = AffineElement(5, 0, inverse=False)  # perfectly inelastic
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             horizontal_sum(inelastic)
 
     def test_upward_sloping_ppf_raises(self):

--- a/tests/test_world_price.py
+++ b/tests/test_world_price.py
@@ -27,5 +27,5 @@ class TestWorldPrice(unittest.TestCase):
         self.assertAlmostEqual(eq.govt_revenue, 4.0)
 
     def test_tariff_requires_world_price(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             Equilibrium(self.demand, self.supply, tariff=1)


### PR DESCRIPTION
## Summary
- use ValueError for invalid symbol settings
- validate demand/supply slopes with ValueError
- raise ValueError for unsupported curve combinations
- use ValueError for invalid policy interventions or tariff usage
- update unit tests to expect ValueError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ca1d3bcc8327a6751e7855575c49