### PR TITLE
Fix show_toc_level duplication

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,6 @@ html_theme_options = {
     "path_to_docs": "docs",
     "home_page_in_toc": True,
     "show_navbar_depth": 2,
-    "show_toc_level": 2,
     "logo": {
         "image_light": "_static/logo.svg",
         "image_dark": "_static/logo.svg",


### PR DESCRIPTION
## Summary
- remove duplicate `show_toc_level` setting in docs configuration

## Testing
- `pre-commit run --files docs/conf.py`

------
https://chatgpt.com/codex/tasks/task_e_68741400d02c83278d72a46d300aa67d